### PR TITLE
feat: UI polish + mobile fixes

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -253,7 +253,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
         ))}
       </div>
 
-      <div className="flex flex-col gap-1 px-4 pb-6 pt-0">
+      <div className="flex flex-col gap-1 px-4 pb-3 md:pb-6 pt-0">
         {replyingTo && (
           <ReplyBar
             message={replyingTo}

--- a/apps/client/src/components/channel-view/text/message-actions.tsx
+++ b/apps/client/src/components/channel-view/text/message-actions.tsx
@@ -101,7 +101,7 @@ const MessageActions = memo(
     );
 
     return (
-      <div className="gap-2 absolute right-0 -top-6 z-10 hidden group-hover:flex [&:has([data-state=open])]:flex items-center space-x-1 rounded-lg shadow-lg border border-border p-1 transition-all h-8">
+      <div className="gap-0.5 absolute right-0 -top-6 z-10 hidden group-hover:flex [&:has([data-state=open])]:flex items-center rounded-md shadow-md border border-border p-0.5 animate-in fade-in-0 slide-in-from-bottom-1 duration-150 h-8">
         {canManage && (
           <>
             <IconButton

--- a/apps/client/src/components/channel-view/voice/index.tsx
+++ b/apps/client/src/components/channel-view/voice/index.tsx
@@ -1,5 +1,6 @@
 import { useVoiceUsersByChannelId } from '@/features/server/hooks';
 import { useVoiceChannelExternalStreamsList } from '@/features/server/voice/hooks';
+import { Volume2 } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { ExternalStreamCard } from './external-stream-card';
 import {
@@ -93,6 +94,9 @@ const VoiceChannel = memo(({ channelId }: TChannelProps) => {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <Volume2 className="h-8 w-8 text-muted-foreground" />
+          </div>
           <p className="text-muted-foreground text-lg mb-2">
             No one in the voice channel
           </p>

--- a/apps/client/src/components/channel-view/voice/voice-grid.tsx
+++ b/apps/client/src/components/channel-view/voice/voice-grid.tsx
@@ -110,7 +110,7 @@ const VoiceGrid = memo(
     return (
       <div
         className={cn(
-          'grid h-full p-2 gap-2',
+          'grid h-full p-3 gap-3',
           getGridClass(gridCols),
           getGridRowsClass(rows),
           className

--- a/apps/client/src/components/channel-view/voice/voice-user-card.tsx
+++ b/apps/client/src/components/channel-view/voice/voice-user-card.tsx
@@ -92,27 +92,35 @@ const VoiceUserCard = memo(
             />
           )}
 
-          <div className="absolute bottom-0 left-0 right-0 p-2">
-            <div className="flex items-center justify-between">
-              <span className="text-white font-medium text-xs truncate">
+          <div className="absolute bottom-0 left-0 right-0 p-2.5">
+            <div className="flex items-center justify-between gap-1.5">
+              <span className="text-white font-medium text-xs truncate drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
                 {voiceUser.name}
               </span>
 
               <div className="flex items-center gap-1">
                 {voiceUser.state.micMuted && (
-                  <MicOff className="size-3.5 text-red-500/80" />
+                  <div className="h-5 w-5 rounded-full bg-red-500/30 backdrop-blur-sm flex items-center justify-center">
+                    <MicOff className="size-3 text-red-400" />
+                  </div>
                 )}
 
                 {voiceUser.state.soundMuted && (
-                  <HeadphoneOff className="size-3.5 text-red-500/80" />
+                  <div className="h-5 w-5 rounded-full bg-red-500/30 backdrop-blur-sm flex items-center justify-center">
+                    <HeadphoneOff className="size-3 text-red-400" />
+                  </div>
                 )}
 
                 {voiceUser.state.webcamEnabled && (
-                  <Video className="size-3.5 text-blue-600/80" />
+                  <div className="h-5 w-5 rounded-full bg-blue-500/30 backdrop-blur-sm flex items-center justify-center">
+                    <Video className="size-3 text-blue-400" />
+                  </div>
                 )}
 
                 {voiceUser.state.sharingScreen && (
-                  <Monitor className="size-3.5 text-purple-500/80" />
+                  <div className="h-5 w-5 rounded-full bg-purple-500/30 backdrop-blur-sm flex items-center justify-center">
+                    <Monitor className="size-3 text-purple-400" />
+                  </div>
                 )}
               </div>
             </div>

--- a/apps/client/src/components/dialogs/confirm-action/index.tsx
+++ b/apps/client/src/components/dialogs/confirm-action/index.tsx
@@ -30,8 +30,14 @@ const ConfirmActionDialog = memo(
     title,
     message,
     confirmLabel,
-    cancelLabel
+    cancelLabel,
+    variant
   }: TConfirmActionDialogProps) => {
+    const isDestructive =
+      variant === 'destructive' ||
+      (confirmLabel &&
+        /delete|remove|leave|kick|ban/i.test(confirmLabel));
+
     return (
       <AlertDialog open={isOpen}>
         <AlertDialogContent>
@@ -46,7 +52,14 @@ const ConfirmActionDialog = memo(
               {cancelLabel ?? 'Cancel'}
             </AlertDialogCancel>
             <AutoFocus>
-              <AlertDialogAction onClick={onConfirm}>
+              <AlertDialogAction
+                onClick={onConfirm}
+                className={
+                  isDestructive
+                    ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                    : undefined
+                }
+              >
                 {confirmLabel ?? 'Confirm'}
               </AlertDialogAction>
             </AutoFocus>

--- a/apps/client/src/components/dialogs/create-channel/index.tsx
+++ b/apps/client/src/components/dialogs/create-channel/index.tsx
@@ -35,15 +35,26 @@ const ChannelTypeItem = ({
 }: TChannelTypeItemProps) => (
   <div
     className={cn(
-      'flex items-center gap-2 p-2 rounded-md cursor-pointer',
-      isActive && 'ring-2 ring-primary bg-primary/10'
+      'flex items-center gap-3 p-3 rounded-lg cursor-pointer border transition-colors',
+      isActive
+        ? 'border-primary bg-primary/10'
+        : 'border-transparent hover:bg-muted/50'
     )}
     onClick={onClick}
   >
-    {icon}
+    <div
+      className={cn(
+        'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg',
+        isActive
+          ? 'bg-primary/20 text-primary'
+          : 'bg-muted text-muted-foreground'
+      )}
+    >
+      {icon}
+    </div>
     <div className="flex flex-col">
-      <span>{title}</span>
-      <span className="text-sm text-primary/60">{description}</span>
+      <span className="font-medium">{title}</span>
+      <span className="text-sm text-muted-foreground">{description}</span>
     </div>
   </div>
 );

--- a/apps/client/src/components/dialogs/create-server/index.tsx
+++ b/apps/client/src/components/dialogs/create-server/index.tsx
@@ -114,17 +114,17 @@ const CreateServerDialog = memo(
               onClick={onCreateSubmit}
               disabled={createLoading || !createValues.name.trim()}
             >
-              Create Server
+              {createLoading ? 'Creating...' : 'Create Server'}
             </Button>
           </div>
 
-          <div className="relative my-2">
+          <div className="relative my-4">
             <div className="absolute inset-0 flex items-center">
               <div className="w-full border-t border-border" />
             </div>
             <div className="relative flex justify-center text-xs uppercase">
               <span className="bg-background px-2 text-muted-foreground">
-                or
+                or join existing
               </span>
             </div>
           </div>
@@ -146,7 +146,7 @@ const CreateServerDialog = memo(
               onClick={onJoinSubmit}
               disabled={joinLoading || !joinValues.inviteCode.trim()}
             >
-              Join Server
+              {joinLoading ? 'Joining...' : 'Join Server'}
             </Button>
           </div>
         </DialogContent>

--- a/apps/client/src/components/dm-call/call-banner.tsx
+++ b/apps/client/src/components/dm-call/call-banner.tsx
@@ -45,10 +45,13 @@ const DmCallBanner = memo(({ dmChannelId }: TDmCallBannerProps) => {
   if (!call || userIds.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-3 bg-emerald-600/20 border-b border-emerald-600/30 px-4 py-2">
-      <Phone className="h-4 w-4 text-emerald-500 animate-pulse" />
+    <div className="flex items-center gap-3 bg-green-500/10 border-b border-green-500/20 px-4 py-2">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-green-500/20">
+        <Phone className="h-3.5 w-3.5 text-green-500 animate-pulse" />
+      </div>
       <div className="flex-1 flex items-center gap-2 text-sm">
-        <span className="text-emerald-400 font-medium">Voice call active</span>
+        <span className="text-green-500 font-medium">Voice call active</span>
+        <span className="text-muted-foreground/60">·</span>
         <span className="text-muted-foreground">
           {userIds.length} {userIds.length === 1 ? 'participant' : 'participants'}
         </span>

--- a/apps/client/src/components/dm-call/dm-voice-panel.tsx
+++ b/apps/client/src/components/dm-call/dm-voice-panel.tsx
@@ -82,12 +82,12 @@ const DmVoicePanel = memo(({ dmChannelId }: TDmVoicePanelProps) => {
         </VoiceGrid>
       </div>
 
-      <div className="flex items-center justify-center gap-2 px-3 py-2 border-t border-border bg-secondary/30">
+      <div className="flex items-center justify-center gap-2.5 px-3 py-2.5 border-t border-border bg-secondary/30">
         <Button
           variant="ghost"
           size="icon"
           className={cn(
-            'h-8 w-8 rounded-md transition-all duration-200',
+            'h-9 w-9 rounded-lg transition-all duration-200',
             ownVoiceState.webcamEnabled
               ? 'bg-green-500/15 hover:bg-green-500/25 text-green-400 hover:text-green-300'
               : 'bg-secondary hover:bg-secondary/80 text-muted-foreground hover:text-foreground'
@@ -111,7 +111,7 @@ const DmVoicePanel = memo(({ dmChannelId }: TDmVoicePanelProps) => {
           variant="ghost"
           size="icon"
           className={cn(
-            'h-8 w-8 rounded-md transition-all duration-200',
+            'h-9 w-9 rounded-lg transition-all duration-200',
             ownVoiceState.sharingScreen
               ? 'bg-blue-500/15 hover:bg-blue-500/25 text-blue-400 hover:text-blue-300'
               : 'bg-secondary hover:bg-secondary/80 text-muted-foreground hover:text-foreground'

--- a/apps/client/src/components/left-sidebar/index.tsx
+++ b/apps/client/src/components/left-sidebar/index.tsx
@@ -108,8 +108,8 @@ const LeftSidebar = memo(({ className }: TLeftSidebarProps) => {
             <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
           </button>
         </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>Server</DropdownMenuLabel>
+            <DropdownMenuContent className="w-56">
+              <DropdownMenuLabel className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold">Server</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <Protect permission={Permission.MANAGE_CATEGORIES}>
                 <DropdownMenuItem

--- a/apps/client/src/components/mobile-bottom-nav/index.tsx
+++ b/apps/client/src/components/mobile-bottom-nav/index.tsx
@@ -11,6 +11,7 @@ import { useHasAnyUnread } from '@/features/server/hooks';
 import { getFileUrl } from '@/helpers/get-file-url';
 import { cn } from '@/lib/utils';
 import { Compass, Home, Server, User } from 'lucide-react';
+import { useKeyboardVisible } from '@/hooks/use-keyboard-visible';
 import { memo, useCallback, useState } from 'react';
 import { ServerScreen } from '../server-screens/screens';
 import {
@@ -28,6 +29,7 @@ const MobileBottomNav = memo(() => {
   const activeServerId = useActiveServerId();
   const hasAnyUnread = useHasAnyUnread();
   const [showServerSheet, setShowServerSheet] = useState(false);
+  const isKeyboardVisible = useKeyboardVisible();
 
   const handleHomeClick = useCallback(() => {
     setActiveView('home');
@@ -55,13 +57,16 @@ const MobileBottomNav = memo(() => {
 
   return (
     <>
-      <nav className="flex md:hidden h-14 w-full border-t border-border bg-sidebar items-center justify-around px-2 pb-[env(safe-area-inset-bottom)]">
+      <nav className={cn(
+        'flex md:hidden h-14 w-full border-t border-border bg-sidebar items-center justify-around px-2 pb-[env(safe-area-inset-bottom)] transition-all duration-200',
+        isKeyboardVisible && 'h-0 overflow-hidden border-t-0 opacity-0 pointer-events-none'
+      )}>
         <button
           onClick={handleHomeClick}
           className={cn(
-            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors',
+            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors relative',
             activeView === 'home'
-              ? 'text-white'
+              ? 'text-foreground'
               : 'text-muted-foreground'
           )}
         >
@@ -74,32 +79,41 @@ const MobileBottomNav = memo(() => {
             )}
           </div>
           <span className="text-[10px]">Home</span>
+          {activeView === 'home' && (
+            <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-0.5 w-6 rounded-full bg-primary" />
+          )}
         </button>
 
         <button
           onClick={handleDiscoverClick}
           className={cn(
-            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors',
+            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors relative',
             activeView === 'discover'
-              ? 'text-white'
+              ? 'text-foreground'
               : 'text-muted-foreground'
           )}
         >
           <Compass className="h-5 w-5" />
           <span className="text-[10px]">Discover</span>
+          {activeView === 'discover' && (
+            <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-0.5 w-6 rounded-full bg-primary" />
+          )}
         </button>
 
         <button
           onClick={handleServersClick}
           className={cn(
-            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors',
+            'flex flex-col items-center justify-center gap-0.5 flex-1 py-1 transition-colors relative',
             activeView === 'server'
-              ? 'text-white'
+              ? 'text-foreground'
               : 'text-muted-foreground'
           )}
         >
           <Server className="h-5 w-5" />
           <span className="text-[10px]">Servers</span>
+          {activeView === 'server' && (
+            <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-0.5 w-6 rounded-full bg-primary" />
+          )}
         </button>
 
         <button

--- a/apps/client/src/components/mobile-header/index.tsx
+++ b/apps/client/src/components/mobile-header/index.tsx
@@ -17,7 +17,7 @@ const MobileHeader = memo(
     const channelType = selectedChannel?.type;
 
     return (
-      <div className="flex md:hidden h-12 w-full border-b border-border items-center px-2 gap-1 bg-background shadow-[0_1px_0_rgba(0,0,0,0.2)]">
+      <div className="flex md:hidden h-12 w-full border-b border-border items-center px-2 gap-1 bg-background">
         <Button
           variant="ghost"
           size="icon"

--- a/apps/client/src/components/search/search-popover.tsx
+++ b/apps/client/src/components/search/search-popover.tsx
@@ -159,13 +159,16 @@ const SearchPopover = memo(({ onClose }: TSearchPopoverProps) => {
       <div className="flex-1 overflow-y-auto">
         {!searched && !loading && (
           <div className="p-6 text-center text-sm text-muted-foreground">
-            Start typing to search messages
+            <Search className="mx-auto mb-2 h-8 w-8 opacity-40" />
+            <p>Start typing to search messages</p>
           </div>
         )}
 
         {searched && results.length === 0 && !loading && (
           <div className="p-6 text-center text-sm text-muted-foreground">
-            No messages found
+            <Search className="mx-auto mb-2 h-8 w-8 opacity-40" />
+            <p>No messages found</p>
+            <p className="text-xs mt-1">Try a different search term</p>
           </div>
         )}
 

--- a/apps/client/src/components/search/search-result.tsx
+++ b/apps/client/src/components/search/search-result.tsx
@@ -53,12 +53,21 @@ const SearchResult = memo(({ message, query, onJump }: TSearchResultProps) => {
   }, [message.channelId, message.id, onJump]);
 
   return (
-    <div className="p-3 hover:bg-secondary/30 border-b border-border/20 last:border-b-0">
+    <div className="p-3 hover:bg-secondary/30 border-b border-border/20 last:border-b-0 group/result">
       <div className="flex items-center gap-1.5 mb-1">
         <Hash className="w-3 h-3 text-muted-foreground" />
-        <span className="text-xs text-muted-foreground font-medium">
+        <span className="text-xs text-muted-foreground font-medium flex-1">
           {channel?.name ?? 'Unknown'}
         </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 px-1.5 text-[10px] opacity-0 group-hover/result:opacity-100 transition-opacity"
+          onClick={handleJump}
+        >
+          Jump
+          <ArrowRight className="w-3 h-3 ml-0.5" />
+        </Button>
       </div>
       <div className="flex items-center gap-2 mb-1">
         <UserAvatar userId={message.userId} className="h-5 w-5" />
@@ -67,19 +76,8 @@ const SearchResult = memo(({ message, query, onJump }: TSearchResultProps) => {
           {format(new Date(message.createdAt), 'MMM d, yyyy h:mm a')}
         </span>
       </div>
-      <div className="text-sm text-muted-foreground pl-7 mb-1.5">
+      <div className="text-sm text-muted-foreground pl-7">
         {highlightMatch(message.content ?? '', query)}
-      </div>
-      <div className="flex justify-end">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 px-2 text-xs"
-          onClick={handleJump}
-        >
-          Jump
-          <ArrowRight className="w-3 h-3 ml-1" />
-        </Button>
       </div>
     </div>
   );

--- a/apps/client/src/components/thread-panel/index.tsx
+++ b/apps/client/src/components/thread-panel/index.tsx
@@ -36,10 +36,10 @@ const ThreadPanel = memo(() => {
   if (!thread) return null;
 
   return (
-    <div className="flex flex-col h-full w-80 border-l border-border/30 bg-background">
+    <div className="flex flex-col h-full w-80 border-l border-border bg-background">
       {/* Header */}
-      <div className="flex items-center gap-2 h-12 px-3 border-b border-border/30 flex-shrink-0">
-        <MessageSquare className="h-4 w-4 text-muted-foreground/60" />
+      <div className="flex items-center gap-2 h-12 px-3 border-b border-border flex-shrink-0">
+        <MessageSquare className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-medium truncate flex-1">
           {thread.name}
         </span>

--- a/apps/client/src/hooks/use-keyboard-visible.ts
+++ b/apps/client/src/hooks/use-keyboard-visible.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+const isTextInput = (el: Element | null): boolean => {
+  if (!el) return false;
+
+  if (el instanceof HTMLInputElement) {
+    const textTypes = ['text', 'search', 'url', 'tel', 'email', 'password', 'number'];
+    return textTypes.includes(el.type);
+  }
+
+  if (el instanceof HTMLTextAreaElement) return true;
+
+  if (el.getAttribute('contenteditable') === 'true') return true;
+
+  // ProseMirror (TiptapInput) uses .ProseMirror contenteditable
+  if (el.closest('.ProseMirror')) return true;
+
+  return false;
+};
+
+const useKeyboardVisible = () => {
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    const handleFocusIn = (e: FocusEvent) => {
+      if (isTextInput(e.target as Element)) {
+        setIsKeyboardVisible(true);
+      }
+    };
+
+    const handleFocusOut = (e: FocusEvent) => {
+      // Small delay to handle focus moving between inputs
+      setTimeout(() => {
+        if (!isTextInput(document.activeElement)) {
+          setIsKeyboardVisible(false);
+        }
+      }, 100);
+    };
+
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, []);
+
+  return isKeyboardVisible;
+};
+
+export { useKeyboardVisible };

--- a/apps/client/src/hooks/use-swipe-gestures.ts
+++ b/apps/client/src/hooks/use-swipe-gestures.ts
@@ -17,6 +17,7 @@ const useSwipeGestures = (handlers: TSwipeHandlers): TSwipeGestureHandlers => {
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     touchStartX.current = e.touches[0].clientX;
+    touchEndX.current = e.touches[0].clientX;
   }, []);
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -211,7 +211,7 @@ body,
 #root {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: 100dvh;
   height: 100%;
 }
 

--- a/apps/client/src/screens/disconnected/index.tsx
+++ b/apps/client/src/screens/disconnected/index.tsx
@@ -15,7 +15,8 @@ const Disconnected = memo(({ info }: TDisconnectedProps) => {
 
     if (code === DisconnectCode.KICKED) {
       return {
-        icon: <AlertCircle className="h-8 w-8 text-yellow-500" />,
+        icon: <AlertCircle className="h-12 w-12 text-yellow-500" />,
+        iconBg: 'bg-yellow-500/10',
         title: 'You have been kicked',
         message: info.reason || 'No reason provided.',
         canReconnect: true
@@ -24,7 +25,8 @@ const Disconnected = memo(({ info }: TDisconnectedProps) => {
 
     if (code === DisconnectCode.BANNED) {
       return {
-        icon: <Gavel className="h-8 w-8 text-red-500" />,
+        icon: <Gavel className="h-12 w-12 text-red-500" />,
+        iconBg: 'bg-red-500/10',
         title: 'You have been banned',
         message: info.reason || 'No reason provided.',
         canReconnect: false
@@ -32,7 +34,8 @@ const Disconnected = memo(({ info }: TDisconnectedProps) => {
     }
 
     return {
-      icon: <WifiOff className="h-8 w-8 text-gray-500" />,
+      icon: <WifiOff className="h-12 w-12 text-muted-foreground" />,
+      iconBg: 'bg-muted',
       title: 'Connection lost',
       message: 'Lost connection to the server unexpectedly.',
       canReconnect: true
@@ -46,7 +49,11 @@ const Disconnected = memo(({ info }: TDisconnectedProps) => {
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
       <div className="text-center space-y-6 max-w-md px-6">
-        <div className="flex justify-center">{disconnectType.icon}</div>
+        <div className="flex justify-center">
+          <div className={`rounded-full p-5 ${disconnectType.iconBg}`}>
+            {disconnectType.icon}
+          </div>
+        </div>
 
         <div className="space-y-2">
           <h1 className="text-2xl font-semibold text-foreground">
@@ -63,7 +70,7 @@ const Disconnected = memo(({ info }: TDisconnectedProps) => {
             className="inline-flex items-center gap-2"
           >
             <RefreshCw className="h-4 w-4" />
-            Go to Connect Screen
+            Reconnect
           </Button>
         )}
 

--- a/apps/client/src/screens/discover-view/index.tsx
+++ b/apps/client/src/screens/discover-view/index.tsx
@@ -323,7 +323,7 @@ const DiscoverView = memo(() => {
   );
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
       <div className="flex h-12 items-center border-b border-border px-4 shadow-sm">
         <Compass className="mr-2 h-5 w-5 text-muted-foreground" />
         <h2 className="font-semibold text-foreground">Discover Servers</h2>

--- a/apps/client/src/screens/home-view/dm-search-popover.tsx
+++ b/apps/client/src/screens/home-view/dm-search-popover.tsx
@@ -169,13 +169,16 @@ const DmSearchPopover = memo(
         <div className="flex-1 overflow-y-auto">
           {!searched && !loading && (
             <div className="p-6 text-center text-sm text-muted-foreground">
-              Start typing to search messages
+              <Search className="mx-auto mb-2 h-8 w-8 opacity-40" />
+              <p>Start typing to search messages</p>
             </div>
           )}
 
           {searched && results.length === 0 && !loading && (
             <div className="p-6 text-center text-sm text-muted-foreground">
-              No messages found
+              <Search className="mx-auto mb-2 h-8 w-8 opacity-40" />
+              <p>No messages found</p>
+              <p className="text-xs mt-1">Try a different search term</p>
             </div>
           )}
 

--- a/apps/client/src/screens/home-view/friends-panel.tsx
+++ b/apps/client/src/screens/home-view/friends-panel.tsx
@@ -99,7 +99,9 @@ const AllFriends = memo(
     if (friends.length === 0) {
       return (
         <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-          <UserPlus className="mb-4 h-12 w-12 opacity-50" />
+          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <UserPlus className="h-8 w-8" />
+          </div>
           <p className="text-lg font-medium">No friends yet</p>
           <p className="text-sm">Add friends to start chatting!</p>
         </div>
@@ -204,8 +206,11 @@ const PendingRequests = memo(() => {
   if (requests.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-        <Check className="mb-4 h-12 w-12 opacity-50" />
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+          <Check className="h-8 w-8" />
+        </div>
         <p className="text-lg font-medium">No pending requests</p>
+        <p className="text-sm">You're all caught up!</p>
       </div>
     );
   }
@@ -368,9 +373,10 @@ const AddFriend = memo(() => {
       )}
 
       {searchQuery.trim() && filteredUsers.length === 0 && (
-        <p className="text-center text-sm text-muted-foreground py-8">
-          No users found matching "{searchQuery}"
-        </p>
+        <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+          <Search className="mb-2 h-8 w-8 opacity-40" />
+          <p className="text-sm">No users found matching "{searchQuery}"</p>
+        </div>
       )}
     </div>
   );

--- a/apps/client/src/screens/home-view/home-sidebar.tsx
+++ b/apps/client/src/screens/home-view/home-sidebar.tsx
@@ -30,7 +30,7 @@ const HomeSidebar = memo(
 
     return (
       <>
-        <div className="flex w-full h-12 items-center border-b border-border px-4 shadow-[0_1px_0_rgba(0,0,0,0.2)]">
+        <div className="flex w-full h-12 items-center border-b border-border px-4">
           <h2 className="font-semibold text-foreground">Home</h2>
         </div>
 
@@ -84,9 +84,12 @@ const HomeSidebar = memo(
             ))}
 
             {dmChannels.length === 0 && (
-              <div className="px-3 py-4 text-center text-sm text-muted-foreground">
-                <MessageSquare className="mx-auto mb-2 h-8 w-8 opacity-50" />
-                <p>No conversations yet</p>
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                  <MessageSquare className="h-6 w-6" />
+                </div>
+                <p className="font-medium">No conversations yet</p>
+                <p className="text-xs mt-1">Start a DM to begin chatting</p>
               </div>
             )}
           </div>

--- a/apps/client/src/screens/home-view/index.tsx
+++ b/apps/client/src/screens/home-view/index.tsx
@@ -63,7 +63,7 @@ const HomeView = memo(() => {
   });
 
   return (
-    <div className="flex flex-col h-full" {...swipeHandlers}>
+    <div className="flex flex-col flex-1 min-h-0" {...swipeHandlers}>
       <MobileHeader
         onToggleLeftDrawer={() => setIsMobileMenuOpen((prev) => !prev)}
         title="Home"

--- a/apps/client/src/screens/main-view/index.tsx
+++ b/apps/client/src/screens/main-view/index.tsx
@@ -27,7 +27,7 @@ const MainView = memo(() => {
   return (
     <VoiceProvider>
       <PersistentAudioStreams />
-      <div className="flex h-screen bg-background text-foreground">
+      <div className="flex h-dvh bg-background text-foreground">
         <div className="hidden md:flex">
           <ServerStrip />
         </div>

--- a/apps/client/src/screens/server-view/index.tsx
+++ b/apps/client/src/screens/server-view/index.tsx
@@ -80,7 +80,7 @@ const ServerView = memo(() => {
 
   return (
     <div
-      className="flex h-full flex-col"
+      className="flex flex-1 min-h-0 flex-col"
       {...swipeHandlers}
     >
       <div className="flex flex-1 overflow-hidden relative">


### PR DESCRIPTION
## Summary
- Comprehensive UI polish across 27 client files — improved empty states, icon containers, animations, and visual hierarchy
- Critical mobile fixes: layout overflow, swipe gesture bug, keyboard-aware bottom nav (iOS compatible)
- New `use-keyboard-visible` hook using focus-based detection for cross-platform keyboard visibility

## UI Polish
- **Disconnected screen**: themed circular icon backgrounds, larger icons, "Reconnect" button text
- **Voice channel**: empty state with Volume2 icon placeholder
- **Voice user cards**: pill-shaped status badges with backdrop blur, drop-shadow on names
- **Message actions**: slide-in animation (`slide-in-from-bottom-1`), tighter spacing
- **Create channel dialog**: icon containers with colored active/inactive backgrounds
- **Create server dialog**: "Creating..."/"Joining..." loading text, "or join existing" divider
- **Confirm action dialog**: auto-destructive styling when label matches Delete/Remove/Leave/Kick/Ban
- **Search popovers**: Search icon + subtitle text in empty states (both server & DM search)
- **Search results**: inline hover Jump button in header row (replaces separate bottom row)
- **Friends panel**: circular `bg-muted` icon backgrounds, "You're all caught up!" subtitle
- **Home sidebar**: removed hardcoded shadow, improved DM empty state with icon + subtitle
- **Thread panel**: `border-border/30` → `border-border` for stronger borders
- **DM call banner**: green circle icon wrapper, dot separator
- **DM voice panel**: larger control buttons (`h-8 w-8` → `h-9 w-9`)
- **Left sidebar dropdown**: wider menu (`w-56`), styled label

## Mobile Critical Fixes
- `h-screen` → `h-dvh` on main view for dynamic viewport height (accounts for mobile browser chrome)
- Views use `flex-1 min-h-0` instead of `h-full` (prevents content overflow behind bottom nav)
- Fixed swipe gesture bug: `touchEndX` now reset on `touchStart` so taps don't trigger false swipes
- Bottom nav hides when keyboard is open via new `useKeyboardVisible` hook (iOS-compatible `focusin`/`focusout`)
- Active tab indicators (primary-colored pill) on mobile bottom nav
- Active tab text uses `text-foreground` instead of `text-white` for theme compatibility
- Reduced bottom padding on mobile text input (`pb-6` → `pb-3 md:pb-6`)
- Removed hardcoded `shadow-[0_1px_0_rgba(0,0,0,0.2)]` from mobile header

## Test plan
- [ ] Verify all 3 themes (light, dark, onyx) render correctly
- [ ] Test mobile layout: input accessible, bottom nav hides on keyboard open
- [ ] Test swipe gestures: tapping message input should NOT open members panel
- [ ] Verify empty states display icons + subtitles across search, friends, DMs, voice
- [ ] Test destructive confirm dialogs (delete message, remove friend, leave server)