### PR TITLE
fix: auto-focus chat input when clicking reply

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -132,6 +132,17 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
   const { files, removeFile, clearFiles, uploading, uploadingSize, handleUploadFiles } =
     useUploadFiles(!canSendMessages);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputAreaRef = useRef<HTMLDivElement>(null);
+
+  const handleReply = useCallback((message: TJoinedMessage) => {
+    setReplyingTo(message);
+    requestAnimationFrame(() => {
+      inputAreaRef.current?.querySelector<HTMLElement>('.ProseMirror')?.focus();
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
+    });
+  }, [containerRef]);
 
   const sendTypingSignal = useMemo(
     () =>
@@ -249,7 +260,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
         className="flex-1 overflow-y-auto overflow-x-hidden pb-4 animate-in fade-in duration-500"
       >
         {groupedMessages.map((group, index) => (
-          <MessagesGroup key={index} group={group} onReply={setReplyingTo} />
+          <MessagesGroup key={index} group={group} onReply={handleReply} />
         ))}
       </div>
 
@@ -289,6 +300,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
           </div>
         )}
         <div
+          ref={inputAreaRef}
           className="flex items-center gap-2 rounded-lg bg-muted px-4 py-2 transition-all duration-200 cursor-text"
           onClick={(e) => {
             if ((e.target as HTMLElement).closest('button')) return;

--- a/apps/client/src/screens/home-view/dm-conversation.tsx
+++ b/apps/client/src/screens/home-view/dm-conversation.tsx
@@ -59,8 +59,20 @@ const DmConversation = memo(({ dmChannelId }: TDmConversationProps) => {
   const ownDmCallChannelId = useOwnDmCallChannelId();
   const isInThisCall = ownDmCallChannelId === dmChannelId;
 
+  const inputAreaRef = useRef<HTMLDivElement>(null);
+
   const { files, removeFile, clearFiles, uploading, uploadingSize, handleUploadFiles } =
     useUploadFiles(false);
+
+  const handleReply = useCallback((message: TJoinedDmMessage) => {
+    setReplyingTo(message);
+    requestAnimationFrame(() => {
+      inputAreaRef.current?.querySelector<HTMLElement>('.ProseMirror')?.focus();
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
+    });
+  }, []);
 
   const sendTypingSignal = useMemo(
     () =>
@@ -179,7 +191,7 @@ const DmConversation = memo(({ dmChannelId }: TDmConversationProps) => {
       >
         <div className="space-y-4">
           {groupedMessages.map((group, index) => (
-            <DmMessagesGroup key={index} group={group} onReply={setReplyingTo} />
+            <DmMessagesGroup key={index} group={group} onReply={handleReply} />
           ))}
         </div>
       </div>
@@ -214,7 +226,7 @@ const DmConversation = memo(({ dmChannelId }: TDmConversationProps) => {
             ))}
           </div>
         )}
-        <div className="flex items-center gap-2 rounded-lg">
+        <div ref={inputAreaRef} className="flex items-center gap-2 rounded-lg">
           <input
             ref={fileInputRef}
             type="file"


### PR DESCRIPTION
## Summary
- Clicking reply on a message now auto-focuses the Tiptap chat input and scrolls to the bottom of the message list
- Applies to both text channels and DM conversations

## Test plan
- [ ] Click reply on a message in a text channel — cursor should appear in the chat input
- [ ] Click reply on a DM message — cursor should appear in the chat input
- [ ] Message list scrolls to bottom so the input is visible