### PR TITLE
fix: federation badge clipped on server icon

### DIFF
--- a/apps/client/src/components/server-strip/index.tsx
+++ b/apps/client/src/components/server-strip/index.tsx
@@ -146,11 +146,11 @@ const FederatedServerIcon = memo(
           ) : (
             <span className="text-lg font-semibold">{firstLetter}</span>
           )}
-          {/* Federation badge */}
-          <div className="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 border border-sidebar text-[8px] font-bold text-white">
-            {instanceInitial}
-          </div>
         </button>
+        {/* Federation badge — outside button to avoid overflow-hidden clipping */}
+        <div className="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 border border-sidebar text-[8px] font-bold text-white pointer-events-none">
+          {instanceInitial}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Move the federated server instance badge **outside** the `<button>` element which has `overflow-hidden`, preventing the badge from being clipped
- Add `pointer-events-none` so clicks still pass through to the server icon button

## Test plan
- [ ] Federated server icons show the full instance initial badge in the bottom-right corner without clipping
- [ ] Clicking the server icon still works (pointer-events-none on badge)