### PR TITLE
fix: home button indicator clipping on hover

### DIFF
--- a/apps/client/src/components/server-strip/index.tsx
+++ b/apps/client/src/components/server-strip/index.tsx
@@ -458,7 +458,7 @@ const ServerStrip = memo(() => {
         <Plus className="h-6 w-6" />
       </button>
 
-      <div className="relative flex items-center justify-center group">
+      <div className="relative flex w-full items-center justify-center group">
         <div className={cn(
           'absolute left-0 w-1 rounded-r-full bg-white transition-all duration-200',
           activeView === 'discover' ? 'h-10' : 'h-0 group-hover:h-5'


### PR DESCRIPTION
## Summary
- Added `w-full` to the Home button wrapper so the left indicator bar aligns to the sidebar strip edge instead of clipping against the button
- Moved `group` class from the button to the wrapper div so the hover indicator animation triggers correctly (matching `ServerIcon` behavior)

## Test plan
- [ ] Hover over the Home button — indicator pill should appear at the far left edge of the sidebar strip
- [ ] Click Home — active indicator should be at the left edge, not overlapping the button
- [ ] Verify server icons still behave the same