### PR TITLE
feat: drag-and-drop server reordering

### DIFF
--- a/apps/client/src/features/app/slice.ts
+++ b/apps/client/src/features/app/slice.ts
@@ -79,6 +79,14 @@ export const appSlice = createSlice({
         state.activeServerId = undefined;
       }
     },
+    reorderJoinedServers: (state, action: PayloadAction<number[]>) => {
+      const serverMap = new Map(
+        state.joinedServers.map((s) => [s.id, s])
+      );
+      state.joinedServers = action.payload
+        .map((id) => serverMap.get(id))
+        .filter((s): s is TServerSummary => !!s);
+    },
     setActiveServerId: (state, action: PayloadAction<number | undefined>) => {
       state.activeServerId = action.payload;
     },

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -117,7 +117,8 @@ const serverMembers = pgTable(
       .references(() => users.id, { onDelete: 'cascade' }),
     joinedAt: bigint('joined_at', { mode: 'number' }).notNull(),
     muted: boolean('muted').notNull().default(false),
-    notificationLevel: text('notification_level').notNull().default('default')
+    notificationLevel: text('notification_level').notNull().default('default'),
+    position: integer('position').notNull().default(0)
   },
   (t) => [
     primaryKey({ columns: [t.serverId, t.userId] }),

--- a/apps/server/src/routers/servers/index.ts
+++ b/apps/server/src/routers/servers/index.ts
@@ -9,6 +9,7 @@ import { joinServerByInviteRoute } from './join';
 import { joinDiscoverRoute } from './join-discover';
 import { joinFederatedRoute } from './join-federated';
 import { leaveServerRoute } from './leave';
+import { reorderServersRoute } from './reorder';
 import { transferOwnerRoute } from './transfer-owner';
 import { updateServerRoute } from './update';
 
@@ -21,6 +22,7 @@ export const serversRouter = t.router({
   joinFederated: joinFederatedRoute,
   discover: discoverServersRoute,
   leave: leaveServerRoute,
+  reorder: reorderServersRoute,
   getAll: getAllServersRoute,
   getMembers: getServerMembersRoute,
   transferOwner: transferOwnerRoute,

--- a/apps/server/src/routers/servers/reorder.ts
+++ b/apps/server/src/routers/servers/reorder.ts
@@ -1,0 +1,31 @@
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import { serverMembers } from '../../db/schema';
+import { protectedProcedure } from '../../utils/trpc';
+
+const reorderServersRoute = protectedProcedure
+  .input(
+    z.object({
+      serverIds: z.array(z.number())
+    })
+  )
+  .mutation(async ({ input, ctx }) => {
+    await db.transaction(async (tx) => {
+      for (let i = 0; i < input.serverIds.length; i++) {
+        const serverId = input.serverIds[i]!;
+
+        await tx
+          .update(serverMembers)
+          .set({ position: i })
+          .where(
+            and(
+              eq(serverMembers.serverId, serverId),
+              eq(serverMembers.userId, ctx.user.id)
+            )
+          );
+      }
+    });
+  });
+
+export { reorderServersRoute };


### PR DESCRIPTION
## Summary
- Adds per-user drag-and-drop reordering of servers in the left sidebar strip using dnd-kit
- New `position` column on `server_members` table with `servers.reorder` tRPC mutation
- Optimistic Redux updates with 8px activation distance to prevent accidental drags during right-click

## Changes
- **Schema**: `position` integer column on `server_members` (default 0)
- **Backend**: `getServersByUserId` orders by position; `addServerMember` calculates `MAX(position) + 1`; new `servers.reorder` mutation (transaction, no permission check — users reorder their own list)
- **Redux**: `reorderJoinedServers` action rebuilds `joinedServers` array in given order
- **Frontend**: `SortableServerItem` wrapper with `useSortable`, `DndContext`/`SortableContext` around local server list (federated servers excluded), Y-axis constrained drag

## Test plan
- [ ] Run DB migration (`db:gen` + push) to add `position` column
- [ ] Join multiple servers, drag to reorder — verify order persists after refresh
- [ ] Verify new servers appear at end of list
- [ ] Verify context menu still works (8px distance prevents accidental drags)
- [ ] Verify federated servers are not draggable

🤖 Generated with [Claude Code](https://claude.com/claude-code)