### PR TITLE
fix: optimize E2EE sender key distribution

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -2,7 +2,7 @@ import { GifPicker } from '@/components/gif-picker';
 import { TiptapInput } from '@/components/tiptap-input';
 import Spinner from '@/components/ui/spinner';
 import { useCan, useChannelCan } from '@/features/server/hooks';
-import { useOwnUserId, useUserById, useUsers } from '@/features/server/users/hooks';
+import { useOwnUserId, useUserById } from '@/features/server/users/hooks';
 import { useSelectedChannel } from '@/features/server/channels/hooks';
 import { useMessages } from '@/features/server/messages/hooks';
 import { useFlatPluginCommands } from '@/features/server/plugins/hooks';
@@ -73,7 +73,6 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
   const slowMode = selectedChannel?.slowMode ?? 0;
   const isE2ee = selectedChannel?.e2ee ?? false;
   const ownUserId = useOwnUserId();
-  const serverUsers = useUsers();
   const allPluginCommands = useFlatPluginCommands();
   const { containerRef, onScroll, scrollToBottom, isAtBottom } = useScrollController({
     channelId,
@@ -175,8 +174,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
 
       if (isE2ee && ownUserId) {
         // Ensure we have a sender key and distribute to members
-        const memberIds = serverUsers.map((u) => u.id);
-        await ensureChannelSenderKey(channelId, ownUserId, memberIds);
+        await ensureChannelSenderKey(channelId, ownUserId);
 
         const encryptedContent = await encryptChannelMessage(
           channelId,
@@ -220,8 +218,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
     replyingTo,
     startSlowModeCooldown,
     isE2ee,
-    ownUserId,
-    serverUsers
+    ownUserId
   ]);
 
   const onFileInputChange = useCallback(
@@ -242,8 +239,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
 
       try {
         if (isE2ee && ownUserId) {
-          const memberIds = serverUsers.map((u) => u.id);
-          await ensureChannelSenderKey(channelId, ownUserId, memberIds);
+          await ensureChannelSenderKey(channelId, ownUserId);
 
           const encryptedContent = await encryptChannelMessage(
             channelId,
@@ -263,7 +259,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
         toast.error(getTrpcError(error, 'Failed to send GIF'));
       }
     },
-    [channelId, isE2ee, ownUserId, serverUsers]
+    [channelId, isE2ee, ownUserId]
   );
 
   const onRemoveFileClick = useCallback(

--- a/apps/client/src/features/server/users/subscriptions.ts
+++ b/apps/client/src/features/server/users/subscriptions.ts
@@ -20,8 +20,6 @@ async function distributeE2eeKeysToUser(joinedUserId: number): Promise<void> {
   const e2eeChannels = state.server.channels.filter((c) => c.e2ee);
   if (e2eeChannels.length === 0) return;
 
-  const memberIds = state.server.users.map((u) => u.id);
-
   const { ensureChannelSenderKey, clearDistributedMember } = await import(
     '@/lib/e2ee'
   );
@@ -33,7 +31,7 @@ async function distributeE2eeKeysToUser(joinedUserId: number): Promise<void> {
 
   for (const channel of e2eeChannels) {
     try {
-      await ensureChannelSenderKey(channel.id, ownUserId, memberIds);
+      await ensureChannelSenderKey(channel.id, ownUserId);
     } catch (err) {
       console.warn(
         `[E2EE] Proactive key distribution failed for channel ${channel.id}:`,


### PR DESCRIPTION
- Fetch channel members from server (getVisibleUsers) instead of distributing to all server users — fixes security for private channels
- Parallel encryption with concurrency limit of 10 + single batch API call (distributeSenderKeysBatch) replaces sequential 1-by-1 distribution
- Identity reset now redistributes to all channel members, not just 2
- Bounded exponential backoff for decryption retries (max 3.5s)
- Persist distributedMembers to IndexedDB so page reloads don't trigger full re-distribution