### PR TITLE
fix: prevent blank messages and auto-detect code on paste

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -24,6 +24,7 @@ import { throttle } from 'lodash-es';
 import { ArrowDown, Clock, Plus, Send, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { preprocessMarkdown } from './renderer/markdown-preprocessor';
+import { isHtmlEmpty } from '@/helpers/is-html-empty';
 import { toast } from 'sonner';
 import { Button } from '../../ui/button';
 import { FileCard } from './file-card';
@@ -164,7 +165,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
   );
 
   const onSendMessage = useCallback(async () => {
-    if ((!newMessage.trim() && !files.length) || !canSendMessages) return;
+    if ((isHtmlEmpty(newMessage) && !files.length) || !canSendMessages) return;
 
     sendTypingSignal.cancel();
 
@@ -409,7 +410,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
             variant="ghost"
             className="h-8 w-8 shrink-0 text-muted-foreground hover:text-primary"
             onClick={onSendMessage}
-            disabled={uploading || !newMessage.trim() || !canSendMessages || slowModeRemaining > 0}
+            disabled={uploading || isHtmlEmpty(newMessage) || !canSendMessages || slowModeRemaining > 0}
           >
             <Send className="h-4 w-4" />
           </Button>

--- a/apps/client/src/components/tiptap-input/index.tsx
+++ b/apps/client/src/components/tiptap-input/index.tsx
@@ -114,6 +114,24 @@ const TiptapInput = memo(
         attributes: {
           'data-placeholder': placeholder ?? 'Message...'
         },
+        handlePaste: (_view, event) => {
+          const text = event.clipboardData?.getData('text/plain');
+          if (!text) return false;
+
+          event.preventDefault();
+
+          // Detect code: clipboard came from a code block, or text contains HTML/XML tags
+          const html = event.clipboardData?.getData('text/html') ?? '';
+          const fromCodeBlock = /<pre[\s>]/i.test(html) || /<code[\s>]/i.test(html);
+          const hasMarkup = /<\/?[a-z][\w-]*(?:\s[^>]*)?\/?>/i.test(text);
+
+          if (fromCodeBlock || hasMarkup) {
+            editor?.chain().focus().setCodeBlock().insertContent(text).run();
+          } else {
+            editor?.commands.insertContent(text);
+          }
+          return true;
+        },
         handleKeyDown: (view, event) => {
           const suggestionElement = document.querySelector('.bg-popover');
           const hasSuggestions =

--- a/apps/client/src/helpers/is-html-empty.ts
+++ b/apps/client/src/helpers/is-html-empty.ts
@@ -1,0 +1,13 @@
+/**
+ * Check if HTML content from TipTap is effectively empty.
+ * Strips tags and whitespace; returns true for empty editors
+ * (e.g. `<p></p>`) while still allowing emoji images and mentions.
+ */
+export function isHtmlEmpty(html: string): boolean {
+  if (!html) return true;
+  // If there are <img> tags (custom emojis, uploaded files), it's not empty
+  if (/<img\s/i.test(html)) return false;
+  // Strip all HTML tags, decode &nbsp;, and check if any text remains
+  const text = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+  return text.length === 0;
+}

--- a/apps/client/src/screens/home-view/dm-conversation.tsx
+++ b/apps/client/src/screens/home-view/dm-conversation.tsx
@@ -27,6 +27,7 @@ import { imageExtensions, TYPING_MS } from '@pulse/shared';
 import { ImageOverride } from '@/components/channel-view/text/overrides/image';
 import { LinkPreview } from '@/components/channel-view/text/overrides/link-preview';
 import { preprocessMarkdown } from '@/components/channel-view/text/renderer/markdown-preprocessor';
+import { isHtmlEmpty } from '@/helpers/is-html-empty';
 import { serializer } from '@/components/channel-view/text/renderer/serializer';
 import type { TFoundMedia } from '@/components/channel-view/text/renderer/types';
 import parse from 'html-react-parser';
@@ -104,7 +105,7 @@ const DmConversation = memo(({ dmChannelId }: TDmConversationProps) => {
   }, [fetching, hasMore, loadMore]);
 
   const onSendMessage = useCallback(async () => {
-    if (!newMessage.trim() && !files.length) return;
+    if (isHtmlEmpty(newMessage) && !files.length) return;
 
     sendTypingSignal.cancel();
 
@@ -270,7 +271,7 @@ const DmConversation = memo(({ dmChannelId }: TDmConversationProps) => {
             variant="ghost"
             className="h-8 w-8"
             onClick={onSendMessage}
-            disabled={uploading || (!newMessage.trim() && !files.length)}
+            disabled={uploading || (isHtmlEmpty(newMessage) && !files.length)}
           >
             <Send className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
- Add isHtmlEmpty helper to properly check empty TipTap HTML content
- Force plain text paste to prevent HTML tag stripping
- Auto-wrap pasted code/HTML in code blocks
- Fix send button disabled state for both channels and DMs