### PR TITLE
fix: align key-backup IndexedDB version with store.ts

### DIFF
--- a/apps/client/src/lib/e2ee/key-backup.ts
+++ b/apps/client/src/lib/e2ee/key-backup.ts
@@ -2,7 +2,7 @@ import { openDB } from 'idb';
 import { arrayBufferToBase64, base64ToArrayBuffer } from './utils';
 
 const HOME_DB_NAME = 'pulse-e2ee';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 const STORE_NAMES = [
   'identityKey',


### PR DESCRIPTION
key-backup.ts was opening the pulse-e2ee database at version 2 while store.ts already upgraded it to version 3, causing IndexedDB to reject the open request during key restore.