### PR TITLE
feat: add 12h/24h time format setting in Appearance

### DIFF
--- a/apps/client/src/components/channel-view/text/messages-group.tsx
+++ b/apps/client/src/components/channel-view/text/messages-group.tsx
@@ -6,6 +6,7 @@ import { useUserById } from '@/features/server/users/hooks';
 import { useAppearanceSettings } from '@/hooks/use-appearance-settings';
 import { cn } from '@/lib/utils';
 import type { TJoinedMessage } from '@pulse/shared';
+import { dateTime, fullDateTime, timeOnly } from '@/helpers/time-format';
 import { format, isToday, isYesterday } from 'date-fns';
 import { memo } from 'react';
 import { Tooltip } from '../../ui/tooltip';
@@ -46,10 +47,10 @@ const MessagesGroup = memo(({ group, onReply }: TMessagesGroupProps) => {
       : undefined;
 
   const timeStr = isToday(date)
-    ? `Today at ${format(date, 'h:mm a')}`
+    ? `Today at ${format(date, timeOnly())}`
     : isYesterday(date)
-      ? `Yesterday at ${format(date, 'h:mm a')}`
-      : format(date, 'MM/dd/yyyy h:mm a');
+      ? `Yesterday at ${format(date, timeOnly())}`
+      : format(date, dateTime());
 
   if (compactMode) {
     return (
@@ -61,9 +62,9 @@ const MessagesGroup = memo(({ group, onReply }: TMessagesGroupProps) => {
         </UserContextMenu>
         <div className="flex min-w-0 flex-col w-full">
           <div className="flex gap-2 items-baseline select-none leading-[1.375rem]">
-            <Tooltip content={format(date, 'PPpp')}>
+            <Tooltip content={format(date, fullDateTime())}>
               <span className="text-muted-foreground/50 text-[10px] shrink-0">
-                {format(date, 'h:mm a')}
+                {format(date, timeOnly())}
               </span>
             </Tooltip>
             <UserContextMenu userId={user.id}>
@@ -130,7 +131,7 @@ const MessagesGroup = memo(({ group, onReply }: TMessagesGroupProps) => {
               BOT
             </span>
           )}
-          <Tooltip content={format(date, 'PPpp')}>
+          <Tooltip content={format(date, fullDateTime())}>
             <span className="text-muted-foreground/50 text-xs">
               {timeStr}
             </span>

--- a/apps/client/src/components/channel-view/text/renderer/index.tsx
+++ b/apps/client/src/components/channel-view/text/renderer/index.tsx
@@ -6,6 +6,7 @@ import { getTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import { imageExtensions, type TJoinedMessage } from '@pulse/shared';
 import { Lock } from 'lucide-react';
+import { fullDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import DOMPurify from 'dompurify';
 import parse from 'html-react-parser';
@@ -129,7 +130,7 @@ const MessageRenderer = memo(({ message }: TMessageRendererProps) => {
       <div className={cn('max-w-full break-words msg-content', isEmojiOnly && 'emoji-only')}>
         {messageHtml}
         {message.edited && (
-          <Tooltip content={message.updatedAt ? `Edited ${format(new Date(message.updatedAt), 'PPpp')}` : 'Edited'}>
+          <Tooltip content={message.updatedAt ? `Edited ${format(new Date(message.updatedAt), fullDateTime())}` : 'Edited'}>
             <span className="text-[10px] text-muted-foreground/50 ml-1 cursor-default">
               (edited)
             </span>

--- a/apps/client/src/components/channel-view/text/system-message.tsx
+++ b/apps/client/src/components/channel-view/text/system-message.tsx
@@ -1,5 +1,6 @@
 import { useUserById } from '@/features/server/users/hooks';
 import { Tooltip } from '@/components/ui/tooltip';
+import { fullDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import { ShieldAlert } from 'lucide-react';
 import { memo } from 'react';
@@ -19,7 +20,7 @@ const SystemMessage = memo(({ message }: SystemMessageProps) => {
   if (message.content === 'identity_reset') {
     return (
       <div className="flex justify-center py-2 px-4">
-        <Tooltip content={format(date, 'PPpp')}>
+        <Tooltip content={format(date, fullDateTime())}>
           <div className="flex items-center gap-2 text-xs text-amber-500 bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-2 max-w-lg select-none">
             <ShieldAlert className="h-4 w-4 shrink-0" />
             <span>

--- a/apps/client/src/components/mod-view-sheet/details/index.tsx
+++ b/apps/client/src/components/mod-view-sheet/details/index.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tooltip } from '@/components/ui/tooltip';
+import { fullDateTime } from '@/helpers/time-format';
 import { format, formatDistanceToNow } from 'date-fns';
 import {
   Calendar,
@@ -110,7 +111,7 @@ const Details = memo(() => {
                 icon={<Gavel className="h-4 w-4 text-muted-foreground" />}
                 label="Banned At"
                 value={format(user.bannedAt ?? 0, 'PPP')}
-                details={format(user.bannedAt ?? 0, 'PPpp')}
+                details={format(user.bannedAt ?? 0, fullDateTime())}
               />
             </>
           )}

--- a/apps/client/src/components/mod-view-sheet/server-activity/messages.tsx
+++ b/apps/client/src/components/mod-view-sheet/server-activity/messages.tsx
@@ -1,6 +1,7 @@
 import { MessageRenderer } from '@/components/channel-view/text/renderer';
 import { PaginatedList } from '@/components/paginated-list';
 import type { TMessage } from '@pulse/shared';
+import { fullDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import { memo, useCallback } from 'react';
 import { useModViewContext } from '../context';
@@ -12,7 +13,7 @@ const Messages = memo(() => {
     (message: TMessage) => (
       <div className="py-2 px-1 border-b border-border last:border-0 bg-secondary/50 rounded-md">
         <span className="text-xs text-muted-foreground">
-          {format(new Date(message.createdAt), 'PPpp')}
+          {format(new Date(message.createdAt), fullDateTime())}
         </span>
         <MessageRenderer
           message={{

--- a/apps/client/src/components/search/search-result.tsx
+++ b/apps/client/src/components/search/search-result.tsx
@@ -2,6 +2,7 @@ import { UserAvatar } from '@/components/user-avatar';
 import { useChannels } from '@/features/server/channels/hooks';
 import { useUserById } from '@/features/server/users/hooks';
 import type { TJoinedMessage } from '@pulse/shared';
+import { longDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import { ArrowRight, Hash } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
@@ -73,7 +74,7 @@ const SearchResult = memo(({ message, query, onJump }: TSearchResultProps) => {
         <UserAvatar userId={message.userId} className="h-5 w-5" />
         <span className="text-sm font-medium">{user?.name ?? 'Unknown'}</span>
         <span className="text-xs text-muted-foreground">
-          {format(new Date(message.createdAt), 'MMM d, yyyy h:mm a')}
+          {format(new Date(message.createdAt), longDateTime())}
         </span>
       </div>
       <div className="text-sm text-muted-foreground pl-7">

--- a/apps/client/src/components/server-screens/server-settings/invites/table-invite.tsx
+++ b/apps/client/src/components/server-screens/server-settings/invites/table-invite.tsx
@@ -13,6 +13,7 @@ import { getTrpcError } from '@/helpers/parse-trpc-errors';
 import { getTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import type { TInvite } from '@pulse/shared';
+import { datePlusTime } from '@/helpers/time-format';
 import { format, formatDistanceToNow } from 'date-fns';
 import { Copy, MoreVertical, Trash2 } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
@@ -129,7 +130,7 @@ const TableInvite = memo(({ invite, refetch }: TTableInviteProps) => {
             'text-destructive': isExpired
           })}
           title={
-            invite.expiresAt ? format(invite.expiresAt, 'PPP p') : undefined
+            invite.expiresAt ? format(invite.expiresAt, datePlusTime()) : undefined
           }
         >
           {expiresText}
@@ -137,7 +138,7 @@ const TableInvite = memo(({ invite, refetch }: TTableInviteProps) => {
       </div>
 
       <div className="flex items-center text-muted-foreground">
-        <span className="text-xs" title={format(invite.createdAt, 'PPP p')}>
+        <span className="text-xs" title={format(invite.createdAt, datePlusTime())}>
           {formatDistanceToNow(invite.createdAt, { addSuffix: true })}
         </span>
       </div>

--- a/apps/client/src/components/server-screens/server-settings/users/table-user.tsx
+++ b/apps/client/src/components/server-screens/server-settings/users/table-user.tsx
@@ -11,6 +11,7 @@ import { useUserRoles } from '@/features/server/hooks';
 import { useUserStatus } from '@/features/server/users/hooks';
 import { cn } from '@/lib/utils';
 import { UserStatus, type TJoinedUser } from '@pulse/shared';
+import { datePlusTime } from '@/helpers/time-format';
 import { format, formatDistanceToNow } from 'date-fns';
 import { MoreVertical, UserCog } from 'lucide-react';
 import { memo, useCallback } from 'react';
@@ -63,7 +64,7 @@ const TableUser = memo(({ user }: TTableUserProps) => {
       </div>
 
       <div className="flex items-center text-muted-foreground">
-        <span className="text-xs" title={format(user.createdAt, 'PPP p')}>
+        <span className="text-xs" title={format(user.createdAt, datePlusTime())}>
           {formatDistanceToNow(user.createdAt, { addSuffix: true })}
         </span>
       </div>

--- a/apps/client/src/components/server-screens/user-settings/appearance/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/appearance/index.tsx
@@ -9,7 +9,8 @@ import {
 import { Slider } from '@/components/ui/slider';
 import {
   useAppearanceSettings,
-  type MessageSpacing
+  type MessageSpacing,
+  type TimeFormat
 } from '@/hooks/use-appearance-settings';
 import { useIsOwnUserOwner } from '@/features/server/hooks';
 import { Check, Circle, Monitor, Moon, Sun } from 'lucide-react';
@@ -63,7 +64,8 @@ const Appearance = memo(() => {
     setCompactMode,
     setMessageSpacing,
     setFontScale,
-    setZoomLevel
+    setZoomLevel,
+    setTimeFormat
   } = useAppearanceSettings();
   const isOwner = useIsOwnUserOwner();
 
@@ -188,6 +190,43 @@ const Appearance = memo(() => {
             <SelectItem value="relaxed">Relaxed</SelectItem>
           </SelectContent>
         </Select>
+      </div>
+
+      {/* Time Format */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold">Time Format</h3>
+          <p className="text-sm text-muted-foreground">
+            Choose how timestamps are displayed.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          {([
+            { value: '12h' as TimeFormat, label: '12 Hour', example: '3:45 PM' },
+            { value: '24h' as TimeFormat, label: '24 Hour', example: '15:45' }
+          ]).map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setTimeFormat(option.value)}
+              className={`relative flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-accent/50 ${
+                settings.timeFormat === option.value
+                  ? 'border-primary bg-accent/30'
+                  : 'border-border'
+              }`}
+            >
+              {settings.timeFormat === option.value && (
+                <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-primary">
+                  <Check className="h-3 w-3 text-primary-foreground" />
+                </div>
+              )}
+              <span className="text-lg font-mono text-muted-foreground">
+                {option.example}
+              </span>
+              <span className="text-sm font-medium">{option.label}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Font Scaling & Zoom — admin only (experimental) */}

--- a/apps/client/src/components/top-bar/pinned-messages-panel.tsx
+++ b/apps/client/src/components/top-bar/pinned-messages-panel.tsx
@@ -4,6 +4,7 @@ import { UserAvatar } from '@/components/user-avatar';
 import { useUserById } from '@/features/server/users/hooks';
 import { getTRPCClient } from '@/lib/trpc';
 import { Permission, type TJoinedMessage } from '@pulse/shared';
+import { longDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import { Pin, PinOff, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
@@ -31,7 +32,7 @@ const PinnedMessageItem = memo(
           <UserAvatar userId={message.userId} className="h-5 w-5" />
           <span className="text-sm font-medium">{user?.name ?? 'Unknown'}</span>
           <span className="text-xs text-muted-foreground">
-            {format(new Date(message.createdAt), 'MMM d, yyyy h:mm a')}
+            {format(new Date(message.createdAt), longDateTime())}
           </span>
         </div>
         <div className="pl-7 text-sm">

--- a/apps/client/src/helpers/time-format.ts
+++ b/apps/client/src/helpers/time-format.ts
@@ -1,0 +1,18 @@
+import { getTimeFormat } from '@/hooks/use-appearance-settings';
+
+const is24h = () => getTimeFormat() === '24h';
+
+/** Time only: "3:45 PM" / "15:45" */
+export const timeOnly = () => (is24h() ? 'HH:mm' : 'h:mm a');
+
+/** Date + time: "01/15/2025 3:45 PM" / "01/15/2025 15:45" */
+export const dateTime = () => (is24h() ? 'MM/dd/yyyy HH:mm' : 'MM/dd/yyyy h:mm a');
+
+/** Long date + time: "Jan 15, 2025 3:45 PM" / "Jan 15, 2025 15:45" */
+export const longDateTime = () => (is24h() ? 'MMM d, yyyy HH:mm' : 'MMM d, yyyy h:mm a');
+
+/** Full date + time (tooltips): "January 15, 2025, 3:45 PM" / "January 15, 2025 15:45" */
+export const fullDateTime = () => (is24h() ? 'PPP HH:mm' : 'PPpp');
+
+/** Date + time (tables): "January 15, 2025 3:45 PM" / "January 15, 2025 15:45" */
+export const datePlusTime = () => (is24h() ? 'PPP HH:mm' : 'PPP p');

--- a/apps/client/src/hooks/use-appearance-settings.ts
+++ b/apps/client/src/hooks/use-appearance-settings.ts
@@ -6,19 +6,22 @@ import {
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
 export type MessageSpacing = 'tight' | 'normal' | 'relaxed';
+export type TimeFormat = '12h' | '24h';
 
 export type AppearanceSettings = {
   compactMode: boolean;
   messageSpacing: MessageSpacing;
   fontScale: number;
   zoomLevel: number;
+  timeFormat: TimeFormat;
 };
 
 const defaultSettings: AppearanceSettings = {
   compactMode: false,
   messageSpacing: 'normal',
   fontScale: 100,
-  zoomLevel: 100
+  zoomLevel: 100,
+  timeFormat: '12h'
 };
 
 let listeners: Array<() => void> = [];
@@ -98,11 +101,19 @@ export const useAppearanceSettings = () => {
     updateSettings({ zoomLevel: value });
   }, []);
 
+  const setTimeFormat = useCallback((value: TimeFormat) => {
+    updateSettings({ timeFormat: value });
+  }, []);
+
   return {
     settings,
     setCompactMode,
     setMessageSpacing,
     setFontScale,
-    setZoomLevel
+    setZoomLevel,
+    setTimeFormat
   };
 };
+
+/** Non-React getter for current time format preference */
+export const getTimeFormat = (): TimeFormat => getSettings().timeFormat;

--- a/apps/client/src/screens/home-view/dm-conversation.tsx
+++ b/apps/client/src/screens/home-view/dm-conversation.tsx
@@ -31,6 +31,7 @@ import { isHtmlEmpty } from '@/helpers/is-html-empty';
 import { serializer } from '@/components/channel-view/text/renderer/serializer';
 import type { TFoundMedia } from '@/components/channel-view/text/renderer/types';
 import parse from 'html-react-parser';
+import { fullDateTime, longDateTime } from '@/helpers/time-format';
 import { format, formatDistance, subDays } from 'date-fns';
 import { filesize } from 'filesize';
 import { throttle } from 'lodash-es';
@@ -644,7 +645,7 @@ const DmPinnedMessageItem = memo(
             {user?.name ?? 'Unknown'}
           </span>
           <span className="text-xs text-muted-foreground">
-            {format(new Date(message.createdAt), 'MMM d, yyyy h:mm a')}
+            {format(new Date(message.createdAt), longDateTime())}
           </span>
         </div>
         <div className="pl-7 text-sm msg-content">
@@ -682,7 +683,7 @@ const DmMessagesGroup = memo(
         <div className="flex min-w-0 flex-col w-full">
           <div className="flex gap-2 items-baseline pl-1 select-none">
             <span className={cn(isOwnUser && 'font-bold')}>{user.name}</span>
-            <Tooltip content={format(date, 'PPpp')}>
+            <Tooltip content={format(date, fullDateTime())}>
               <span className="text-primary/60 text-xs">
                 {formatDistance(subDays(date, 0), new Date(), {
                   addSuffix: true

--- a/apps/client/src/screens/home-view/dm-search-popover.tsx
+++ b/apps/client/src/screens/home-view/dm-search-popover.tsx
@@ -3,6 +3,7 @@ import { UserAvatar } from '@/components/user-avatar';
 import { useUserById } from '@/features/server/users/hooks';
 import { getTRPCClient } from '@/lib/trpc';
 import type { TJoinedDmMessage } from '@pulse/shared';
+import { longDateTime } from '@/helpers/time-format';
 import { format } from 'date-fns';
 import parse from 'html-react-parser';
 import { Loader2, Search, X } from 'lucide-react';
@@ -32,7 +33,7 @@ const DmSearchResult = memo(
             {user?.name ?? 'Unknown'}
           </span>
           <span className="text-xs text-muted-foreground">
-            {format(new Date(message.createdAt), 'MMM d, yyyy h:mm a')}
+            {format(new Date(message.createdAt), longDateTime())}
           </span>
         </div>
         <div className="pl-7 text-sm msg-content">


### PR DESCRIPTION
Adds a user-configurable time format preference (12-hour or 24-hour) to the Appearance settings. All timestamp formatting across the app now respects this setting, including channel messages, DMs, search results, pinned messages, mod view, invites, and user tables.