### PR TITLE
fix: load federated servers and refresh messages after login/key restore

### DIFF
--- a/apps/client/src/components/e2ee-setup-modal.tsx
+++ b/apps/client/src/components/e2ee-setup-modal.tsx
@@ -10,6 +10,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { setupE2EEKeys } from '@/lib/e2ee';
+import { store } from '@/features/store';
+import { serverSliceActions } from '@/features/server/slice';
 import { getHomeTRPCClient } from '@/lib/trpc';
 import { toast } from 'sonner';
 import { AlertTriangle, KeyRound, Loader2 } from 'lucide-react';
@@ -67,6 +69,7 @@ const E2EESetupModal = memo(() => {
     setError('');
     try {
       await setupE2EEKeys('restore', passphrase);
+      store.dispatch(serverSliceActions.clearAllMessages());
       setOpen(false);
       toast.success('Encryption keys restored from server backup');
       resolveRef.current?.();
@@ -81,6 +84,7 @@ const E2EESetupModal = memo(() => {
     setError('');
     try {
       await setupE2EEKeys('generate');
+      store.dispatch(serverSliceActions.clearAllMessages());
       setOpen(false);
       toast.success(
         'Encryption keys generated. Back up your keys in Settings > Encryption.'

--- a/apps/client/src/features/server/slice.ts
+++ b/apps/client/src/features/server/slice.ts
@@ -280,6 +280,9 @@ export const serverSlice = createSlice({
     ) => {
       state.messagesMap[action.payload.channelId] = [];
     },
+    clearAllMessages: (state) => {
+      state.messagesMap = {};
+    },
     clearTypingUsers: (state, action: PayloadAction<number>) => {
       delete state.typingMap[action.payload];
     },

--- a/apps/client/src/screens/connect/index.tsx
+++ b/apps/client/src/screens/connect/index.tsx
@@ -5,8 +5,9 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { joinServerByInvite, switchServer } from '@/features/app/actions';
+import { joinServerByInvite, loadFederatedServers, switchServer } from '@/features/app/actions';
 import { connect, getHandshakeHash } from '@/features/server/actions';
+import { initE2EE } from '@/lib/e2ee';
 import { useInfo } from '@/features/server/hooks';
 import { getFileUrl, getUrlFromServer } from '@/helpers/get-file-url';
 import {
@@ -112,6 +113,10 @@ const Connect = memo(() => {
 
       await connect();
 
+      // Initialize E2EE and load federated servers (mirrors loadApp() flow)
+      initE2EE().catch((err) => console.error('E2EE initialization failed:', err));
+      await loadFederatedServers();
+
       // If there's an invite code, join that server and switch to it
       if (inviteCode) {
         try {
@@ -167,6 +172,10 @@ const Connect = memo(() => {
       });
 
       await connect();
+
+      // Initialize E2EE and load federated servers (mirrors loadApp() flow)
+      initE2EE().catch((err) => console.error('E2EE initialization failed:', err));
+      await loadFederatedServers();
 
       // If there's an invite code, join that server and switch to it
       if (inviteCode) {


### PR DESCRIPTION
The Connect screen's login and register handlers only called connect() but skipped initE2EE() and loadFederatedServers(), causing federated servers to not appear until a page refresh. Additionally, after E2EE key restore/generation, cached messages were not re-fetched, leaving encrypted messages showing [Unable to decrypt] until reload.

- Call initE2EE() and loadFederatedServers() after connect() in both login and register flows to match the loadApp() auto-connect path
- Add clearAllMessages reducer to wipe cached messages after E2EE key setup, forcing re-fetch with decryption using the new keys