### PR TITLE
fix(federation): allow non-admin users to discover active federated i…

### DIFF
--- a/apps/client/src/screens/discover-view/index.tsx
+++ b/apps/client/src/screens/discover-view/index.tsx
@@ -11,7 +11,7 @@ import { getFileUrl } from '@/helpers/get-file-url';
 import { getTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import type {
-  TFederationInstanceSummary,
+  TFederationActiveInstance,
   TRemoteServerSummary,
   TServerSummary
 } from '@pulse/shared';
@@ -189,7 +189,7 @@ const DiscoverView = memo(() => {
   const federatedServers = useFederatedServers();
 
   // Federated state
-  const [instances, setInstances] = useState<TFederationInstanceSummary[]>([]);
+  const [instances, setInstances] = useState<TFederationActiveInstance[]>([]);
   const [remoteServers, setRemoteServers] = useState<TRemoteServerSummary[]>(
     []
   );
@@ -245,8 +245,7 @@ const DiscoverView = memo(() => {
         try {
           const trpc = getTRPCClient();
           if (!trpc) return;
-          const fedInstances = await trpc.federation.listInstances.query();
-          const active = fedInstances.filter((i) => i.status === 'active');
+          const active = await trpc.federation.listActiveInstances.query();
           setInstances(active);
 
           // Fetch servers from all active instances

--- a/apps/server/src/db/queries/federation.ts
+++ b/apps/server/src/db/queries/federation.ts
@@ -41,9 +41,22 @@ async function listFederationInstances() {
   return db.select().from(federationInstances);
 }
 
+async function listActiveFederationInstances() {
+  return db
+    .select({
+      id: federationInstances.id,
+      domain: federationInstances.domain,
+      name: federationInstances.name,
+      lastSeenAt: federationInstances.lastSeenAt
+    })
+    .from(federationInstances)
+    .where(eq(federationInstances.status, 'active'));
+}
+
 export {
   getActiveFederationInstanceByDomain,
   getFederationInstanceByDomain,
   getFederationInstanceById,
+  listActiveFederationInstances,
   listFederationInstances
 };

--- a/apps/server/src/routers/__tests__/federation-membership.test.ts
+++ b/apps/server/src/routers/__tests__/federation-membership.test.ts
@@ -236,6 +236,54 @@ describe('listInstances permission gate (F8)', () => {
   });
 });
 
+describe('listActiveInstances (public discovery)', () => {
+  test('non-admin user CAN list active federation peers', async () => {
+    const { caller } = await initTest(2);
+    await createTestInstance('public-peer.example.com', 'Public Peer');
+    const instances = await caller.federation.listActiveInstances();
+    expect(instances.some((i) => i.domain === 'public-peer.example.com')).toBe(
+      true
+    );
+  });
+
+  test('omits pending and blocked peers', async () => {
+    const { caller } = await initTest(2);
+    await createTestInstance('active-peer.example.com', 'Active Peer');
+    await db.insert(federationInstances).values({
+      domain: 'pending-peer.example.com',
+      name: 'Pending Peer',
+      status: 'pending',
+      direction: 'outgoing',
+      createdAt: Date.now()
+    });
+    await db.insert(federationInstances).values({
+      domain: 'blocked-peer.example.com',
+      name: 'Blocked Peer',
+      status: 'blocked',
+      direction: 'outgoing',
+      createdAt: Date.now()
+    });
+
+    const instances = await caller.federation.listActiveInstances();
+    const domains = instances.map((i) => i.domain);
+    expect(domains).toContain('active-peer.example.com');
+    expect(domains).not.toContain('pending-peer.example.com');
+    expect(domains).not.toContain('blocked-peer.example.com');
+  });
+
+  test('does not expose operator metadata fields', async () => {
+    const { caller } = await initTest(2);
+    await createTestInstance('meta-peer.example.com', 'Meta Peer');
+    const instances = await caller.federation.listActiveInstances();
+    const peer = instances.find((i) => i.domain === 'meta-peer.example.com');
+    expect(peer).toBeDefined();
+    // status, direction, createdAt are operator-sensitive — must not leak
+    expect(peer).not.toHaveProperty('status');
+    expect(peer).not.toHaveProperty('direction');
+    expect(peer).not.toHaveProperty('createdAt');
+  });
+});
+
 describe('ensureShadowUser remote verification (F5)', () => {
   test('refuses to create shadow when remote instance is unreachable', async () => {
     const { caller } = await initTest();

--- a/apps/server/src/routers/federation/index.ts
+++ b/apps/server/src/routers/federation/index.ts
@@ -11,6 +11,7 @@ import { getConfigRoute } from './get-config';
 import { getJoinedRoute } from './get-joined';
 import { joinRemoteRoute } from './join-remote';
 import { leaveRemoteRoute } from './leave-remote';
+import { listActiveInstancesRoute } from './list-active-instances';
 import { listInstancesRoute } from './list-instances';
 import { removeInstanceRoute } from './remove-instance';
 import { requestTokenRoute } from './request-token';
@@ -21,6 +22,7 @@ export const federationRouter = t.router({
   setConfig: setConfigRoute,
   generateKeys: generateKeysRoute,
   listInstances: listInstancesRoute,
+  listActiveInstances: listActiveInstancesRoute,
   addInstance: addInstanceRoute,
   acceptInstance: acceptInstanceRoute,
   removeInstance: removeInstanceRoute,

--- a/apps/server/src/routers/federation/list-active-instances.ts
+++ b/apps/server/src/routers/federation/list-active-instances.ts
@@ -1,0 +1,18 @@
+import { listActiveFederationInstances } from '../../db/queries/federation';
+import { protectedProcedure } from '../../utils/trpc';
+
+// User-facing federation discovery. Returns only `active` peers and
+// only the fields the client needs to render the discover view.
+// Pending/blocked rows and direction (incoming/outgoing/mutual) are
+// operator metadata and stay behind `listInstances`'s admin gate.
+const listActiveInstancesRoute = protectedProcedure.query(async () => {
+  const instances = await listActiveFederationInstances();
+  return instances.map((i) => ({
+    id: i.id,
+    domain: i.domain,
+    name: i.name,
+    lastSeenAt: i.lastSeenAt
+  }));
+});
+
+export { listActiveInstancesRoute };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -220,6 +220,15 @@ export type TFederationInstanceSummary = {
   createdAt: number;
 };
 
+// Public-facing slice of a federation peer for the discover view.
+// Excludes operator-sensitive metadata (status, direction, createdAt).
+export type TFederationActiveInstance = {
+  id: number;
+  domain: string;
+  name: string | null;
+  lastSeenAt: number | null;
+};
+
 export type TFederationConfig = {
   enabled: boolean;
   domain: string;


### PR DESCRIPTION
…nstances (#65)

The F8 admin gate on `federation.listInstances` blocked the discover view for normal users (FORBIDDEN: Insufficient permissions), since that procedure is the source of truth for "which active peers can I see servers from". Splitting the audience instead of widening the gate: admin-only `listInstances` keeps the full operator view (pending/blocked/direction/createdAt), and a new public-facing `listActiveInstances` returns only the fields the discover view needs (id, domain, name, lastSeenAt) for `active`-status peers.

- Add `listActiveFederationInstances` query (filters status='active', selects only public columns at the DB layer).
- Add `federation.listActiveInstances` protected procedure.
- Switch `discover-view` to the new procedure; drop now-redundant client-side filter and the unused `TFederationInstanceSummary` import.
- New `TFederationActiveInstance` shared type.
- Tests: non-admin can list, pending/blocked omitted, operator metadata fields not exposed.