### PR TITLE
fix(federation): route account-level operations through home tRPC client

### DIFF
--- a/apps/client/src/components/dialogs/add-dm-members.tsx
+++ b/apps/client/src/components/dialogs/add-dm-members.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/user-avatar';
 import { useFriends } from '@/features/friends/hooks';
 import { getTrpcError } from '@/helpers/parse-trpc-errors';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import { Check, X } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -56,7 +56,7 @@ const AddDmMembersDialog = memo(
       if (selectedIds.length === 0 || adding) return;
       setAdding(true);
 
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) {
         setAdding(false);
         return;

--- a/apps/client/src/components/dialogs/create-group-dm.tsx
+++ b/apps/client/src/components/dialogs/create-group-dm.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/user-avatar';
 import { useFriends } from '@/features/friends/hooks';
 import { getTrpcError } from '@/helpers/parse-trpc-errors';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import { Check, X } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
@@ -35,7 +35,7 @@ const CreateGroupDmDialog = memo(
 
       setCreating(true);
 
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) {
         setCreating(false);
         return;

--- a/apps/client/src/components/server-screens/server-settings/federation/index.tsx
+++ b/apps/client/src/components/server-screens/server-settings/federation/index.tsx
@@ -10,7 +10,7 @@ import { Group } from '@/components/ui/group';
 import { Input } from '@/components/ui/input';
 import { LoadingCard } from '@/components/ui/loading-card';
 import { Switch } from '@/components/ui/switch';
-import { getTRPCClient, getHomeTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import type {
   TFederationConfig,
   TFederationInstanceSummary
@@ -57,7 +57,7 @@ const Federation = memo(() => {
 
   const fetchData = useCallback(async () => {
     try {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
       const [configResult, instancesResult] = await Promise.all([
         trpc.federation.getConfig.query(),
@@ -93,7 +93,7 @@ const Federation = memo(() => {
 
   const handleSaveConfig = useCallback(async () => {
     try {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
       await trpc.federation.setConfig.mutate({ enabled, domain });
       toast.success('Federation settings saved');
@@ -109,7 +109,7 @@ const Federation = memo(() => {
 
     setAdding(true);
     try {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
       await trpc.federation.addInstance.mutate({ remoteUrl: addUrl });
       setAddUrl('');
@@ -127,7 +127,7 @@ const Federation = memo(() => {
   const handleAccept = useCallback(
     async (instanceId: number) => {
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         await trpc.federation.acceptInstance.mutate({ instanceId });
         toast.success('Federation accepted');
@@ -143,7 +143,7 @@ const Federation = memo(() => {
   const handleBlock = useCallback(
     async (instanceId: number) => {
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         await trpc.federation.blockInstance.mutate({ instanceId });
         toast.success('Instance blocked');
@@ -159,7 +159,7 @@ const Federation = memo(() => {
   const handleRemove = useCallback(
     async (instanceId: number) => {
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         await trpc.federation.removeInstance.mutate({ instanceId });
         toast.success('Instance removed');

--- a/apps/client/src/components/server-screens/user-settings/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { requestConfirmation } from '@/features/dialogs/actions';
 import { disconnectFromServer } from '@/features/server/actions';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { ChevronLeft, Fingerprint, LogOut, Monitor, Palette, User, Lock, ShieldCheck, Volume2 } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import type { TServerScreenBaseProps } from '../screens';
@@ -93,7 +93,7 @@ const UserSettings = memo(({ close, initialSection, initialVerifyPeerId }: TUser
 
   useEffect(() => {
     let cancelled = false;
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     trpc.users.getAuthProviders

--- a/apps/client/src/components/server-screens/user-settings/password/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/password/index.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/ui/input';
 import { SettingsFormFooter } from '@/components/ui/settings-form-footer';
 import { closeServerScreens } from '@/features/server-screens/actions';
 import { useForm } from '@/hooks/use-form';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { memo, useCallback } from 'react';
 import { toast } from 'sonner';
 
@@ -15,7 +15,7 @@ const Password = memo(() => {
   });
 
   const updatePassword = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {

--- a/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
@@ -4,7 +4,7 @@ import { UserAvatar } from '@/components/user-avatar';
 import { getTrpcError } from '@/helpers/parse-trpc-errors';
 import { uploadFile } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import type { TJoinedPublicUser } from '@pulse/shared';
 import { Upload } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
@@ -22,7 +22,7 @@ const AvatarManager = memo(({ user }: TAvatarManagerProps) => {
   const [pickedFile, setPickedFile] = useState<File | null>(null);
 
   const removeAvatar = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {
@@ -49,7 +49,7 @@ const AvatarManager = memo(({ user }: TAvatarManagerProps) => {
 
   const handleCropConfirm = useCallback(async (cropped: File) => {
     setPickedFile(null);
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {

--- a/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
@@ -4,7 +4,7 @@ import { getFileUrl } from '@/helpers/get-file-url';
 import { getTrpcError } from '@/helpers/parse-trpc-errors';
 import { uploadFile } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import type { TJoinedPublicUser } from '@pulse/shared';
 import { Upload } from 'lucide-react';
@@ -19,7 +19,7 @@ const BannerManager = memo(({ user }: TBannerManagerProps) => {
   const openFilePicker = useFilePicker();
 
   const removeBanner = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {
@@ -32,7 +32,7 @@ const BannerManager = memo(({ user }: TBannerManagerProps) => {
   }, []);
 
   const onBannerClick = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {

--- a/apps/client/src/components/server-screens/user-settings/profile/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/index.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { closeServerScreens } from '@/features/server-screens/actions';
 import { useOwnPublicUser } from '@/features/server/users/hooks';
 import { useForm } from '@/hooks/use-form';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { memo, useCallback } from 'react';
 import { toast } from 'sonner';
 import { AvatarManager } from './avatar-manager';
@@ -21,7 +21,7 @@ const Profile = memo(() => {
   });
 
   const onUpdateUser = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {

--- a/apps/client/src/hooks/use-auto-away.ts
+++ b/apps/client/src/hooks/use-auto-away.ts
@@ -1,4 +1,4 @@
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { UserStatus } from '@pulse/shared';
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -30,7 +30,7 @@ export const useAutoAway = () => {
 
   useEffect(() => {
     const setStatus = (status: SetableStatus) => {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
       trpc.users.setStatus.mutate({ status }).catch(() => {});
     };

--- a/apps/client/src/screens/discover-view/index.tsx
+++ b/apps/client/src/screens/discover-view/index.tsx
@@ -8,7 +8,7 @@ import { getHandshakeHash } from '@/features/server/actions';
 import { store } from '@/features/store';
 import { EmptyState } from '@/components/ui/empty-state';
 import { getFileUrl } from '@/helpers/get-file-url';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 import type {
   TFederationActiveInstance,
@@ -223,7 +223,7 @@ const DiscoverView = memo(() => {
   useEffect(() => {
     const fetchServers = async () => {
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         const data = await trpc.servers.discover.query();
         setServers(data);
@@ -243,7 +243,7 @@ const DiscoverView = memo(() => {
       const fetchFederated = async () => {
         setFedLoading(true);
         try {
-          const trpc = getTRPCClient();
+          const trpc = getHomeTRPCClient();
           if (!trpc) return;
           const active = await trpc.federation.listActiveInstances.query();
           setInstances(active);
@@ -291,7 +291,7 @@ const DiscoverView = memo(() => {
     setJoiningId(serverId);
 
     try {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
       const summary = await trpc.servers.joinDiscover.mutate({ serverId, password });
 
@@ -342,7 +342,7 @@ const DiscoverView = memo(() => {
       setJoiningFedPublicId(server.publicId);
 
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
 
         // Find the instance

--- a/apps/client/src/screens/home-view/dm-conversation.tsx
+++ b/apps/client/src/screens/home-view/dm-conversation.tsx
@@ -34,7 +34,7 @@ import { isGiphyEnabled } from '@/helpers/giphy';
 import { getTrpcError } from '@/helpers/parse-trpc-errors';
 import { useDecryptedFileUrl } from '@/hooks/use-decrypted-file-url';
 import { useUploadFiles } from '@/hooks/use-upload-files';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -180,7 +180,7 @@ const DmConversation = memo(
   const sendTypingSignal = useMemo(
     () =>
       throttle(async () => {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         try {
           await trpc.dms.signalTyping.mutate({ dmChannelId });
@@ -769,7 +769,7 @@ const DmPinnedMessagesPanel = memo(
       setLoading(true);
 
       try {
-        const trpc = getTRPCClient();
+        const trpc = getHomeTRPCClient();
         if (!trpc) return;
         const messages = await trpc.dms.getPinned.query({ dmChannelId });
         // Same batch decryptor used by history + live + banner so E2EE
@@ -800,7 +800,7 @@ const DmPinnedMessagesPanel = memo(
     }, [dmChannelId, fetchPinned]);
 
     const onUnpin = useCallback(async (dmMessageId: number) => {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
 
       try {
@@ -1040,7 +1040,7 @@ const DmMessage = memo(({ message, onReply }: { message: TJoinedDmMessage; onRep
 
   const handleToggleReaction = useCallback(
     async (emoji: string) => {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
 
       try {
@@ -1056,7 +1056,7 @@ const DmMessage = memo(({ message, onReply }: { message: TJoinedDmMessage; onRep
   );
 
   const handlePinToggle = useCallback(async () => {
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
 
     try {
@@ -1076,7 +1076,7 @@ const DmMessage = memo(({ message, onReply }: { message: TJoinedDmMessage; onRep
 
   const onEmojiSelect = useCallback(
     async (emoji: TEmojiItem) => {
-      const trpc = getTRPCClient();
+      const trpc = getHomeTRPCClient();
       if (!trpc) return;
 
       try {

--- a/apps/client/src/screens/home-view/dm-pin-banner.tsx
+++ b/apps/client/src/screens/home-view/dm-pin-banner.tsx
@@ -3,7 +3,7 @@ import { PinBannerShell } from '@/components/chat-primitives/pin-banner-shell';
 import { decryptDmMessages } from '@/features/dms/actions';
 import { useUserById } from '@/features/server/users/hooks';
 import { stripToPlainText } from '@/helpers/strip-to-plain-text';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import type { TJoinedDmMessage } from '@pulse/shared';
 import parse from 'html-react-parser';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -21,7 +21,7 @@ const DmPinBanner = memo(({ dmChannelId }: { dmChannelId: number }) => {
 
   const fetchLatest = useCallback(async () => {
     if (!dmChannelId) return;
-    const trpc = getTRPCClient();
+    const trpc = getHomeTRPCClient();
     if (!trpc) return;
     try {
       const messages = await trpc.dms.getPinned.query({ dmChannelId });

--- a/apps/client/src/screens/home-view/dm-search-popover.tsx
+++ b/apps/client/src/screens/home-view/dm-search-popover.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { UserAvatar } from '@/components/user-avatar';
 import { useUserById } from '@/features/server/users/hooks';
 import { longDateTime } from '@/helpers/time-format';
-import { getTRPCClient } from '@/lib/trpc';
+import { getHomeTRPCClient } from '@/lib/trpc';
 import type { TJoinedDmMessage } from '@pulse/shared';
 import { format } from 'date-fns';
 import parse from 'html-react-parser';
@@ -71,7 +71,7 @@ const DmSearchPopover = memo(
         setLoading(true);
 
         try {
-          const trpc = getTRPCClient();
+          const trpc = getHomeTRPCClient();
           if (!trpc) {
             setLoading(false);
             return;


### PR DESCRIPTION
Federation regression: when browsing a federated server, the active tRPC client routes calls to that federated instance. Account-level operations (DMs, user profile/avatar/banner/password/status, federation config, server discovery) were silently hitting the wrong instance, leaking that instance's data into the user's UI and dropping mutations into the wrong backend.

Most visible symptom: opening Discover while browsing a federated server showed THAT server's local-server list under the "Local" tab and THAT server's federated peers under the "Federated" tab — a recursion of someone else's federation topology, with join attempts pointed at the wrong issuer.

Switch all such call sites to `getHomeTRPCClient()` so they always target the user's home instance regardless of active server. Server- scoped operations (channel messages, server settings, server voice, channel notification settings) still use the active-instance router and are unaffected.

Sites migrated (24 total across 13 files):
- screens/discover-view/index.tsx (5) — server discovery + federation peer enumeration + federation join-token issuance
- screens/home-view/dm-conversation.tsx (6) — signalTyping, getPinned, pinMessage, unpinMessage, toggleReaction
- screens/home-view/dm-pin-banner.tsx (1) — dms.getPinned
- screens/home-view/dm-search-popover.tsx (1) — dms.searchMessages
- components/dialogs/create-group-dm.tsx (1) — dms.createGroup
- components/dialogs/add-dm-members.tsx (1) — dms.addMember
- components/server-screens/user-settings/index.tsx (1) — getAuthProviders
- components/server-screens/user-settings/password/index.tsx (1) — updatePassword
- components/server-screens/user-settings/profile/index.tsx (1) — users.update
- components/server-screens/user-settings/profile/avatar-manager.tsx (2) — changeAvatar
- components/server-screens/user-settings/profile/banner-manager.tsx (2) — changeBanner
- hooks/use-auto-away.ts (1) — users.setStatus
- components/server-screens/server-settings/federation/index.tsx (6) — getConfig, setConfig, addInstance, acceptInstance, blockInstance, removeInstance (one subscription site already correctly used the home client; the rest were inconsistent)