### PR TITLE
feat(federation/D2): client cross-instance DM session + federated gro…

### DIFF
--- a/apps/client/src/lib/e2ee/index.ts
+++ b/apps/client/src/lib/e2ee/index.ts
@@ -434,13 +434,45 @@ async function rotateSignedPreKeyIfNeeded(
 }
 
 /**
+ * Look up a user's federation status from Redux. `_identity` is set
+ * to `name@domain` for federated users (joined-user query in
+ * apps/server/src/db/queries/users.ts) and undefined for local users.
+ *
+ * Best-effort: if Redux isn't ready or the user isn't in any
+ * loaded slice, default to local. A wrong guess is self-correcting
+ * — the wrong-route fetch returns null and the caller surfaces it
+ * as a clear "encrypted DM unavailable" failure per Decision 2.
+ */
+async function isUserFederated(userId: number): Promise<boolean> {
+  try {
+    const { store: reduxStore } = await import('@/features/store');
+    const state = reduxStore.getState();
+    const user =
+      state.server.users.find((u) => u.id === userId) ??
+      state.friends.friends.find((f) => f.id === userId);
+    return !!user?._identity && user._identity.includes('@');
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Ensure we have a session with a user. If not, fetch their pre-key bundle
  * and establish one via X3DH.
  *
- * When `verifyIdentity` is true, checks whether the remote user's server-side
- * identity key still matches what we have stored locally. If it changed (key
- * reset), the stale session is cleared and a fresh one is built. This avoids
- * encrypting with an old session that the reset user can't decrypt.
+ * When `verifyIdentity` is true (same-instance only), checks whether
+ * the remote user's server-side identity key still matches what we
+ * have stored locally. If it changed (key reset), the stale session
+ * is cleared and a fresh one is built. This avoids encrypting with
+ * an old session that the reset user can't decrypt.
+ *
+ * For federated users (Phase D / D2), the bundle is fetched via
+ * `e2ee.getFederatedPreKeyBundle` — the home server proxies the
+ * request to the recipient's instance and verifies the signed
+ * response (Phase D / D0). The verifyIdentity branch is skipped:
+ * D3's identity-rotation broadcast handles cross-instance rotation;
+ * stale federated sessions surface the identity-changed modal on
+ * the next decrypt attempt.
  */
 async function ensureSession(
   userId: number,
@@ -454,8 +486,10 @@ async function ensureSession(
   const trpc = opts?.trpc ?? getHomeTRPCClient();
   if (!trpc) throw new Error('Not connected');
 
+  const federated = await isUserFederated(userId);
+
   if (await hasSession(userId, s)) {
-    if (opts?.verifyIdentity) {
+    if (opts?.verifyIdentity && !federated) {
       const serverKey = await trpc.e2ee.getIdentityPublicKey.query({ userId });
       const localKey = await s.getStoredIdentityKey(userId);
 
@@ -470,10 +504,19 @@ async function ensureSession(
     }
   }
 
-  const bundle = await trpc.e2ee.getPreKeyBundle.query({ userId });
+  const bundle = federated
+    ? await trpc.e2ee.getFederatedPreKeyBundle.query({ userId })
+    : await trpc.e2ee.getPreKeyBundle.query({ userId });
 
   if (!bundle) {
-    throw new Error(`User ${userId} has no E2EE keys registered`);
+    // Decision 2: hard fail. Caller surfaces this as a clear
+    // "encrypted DM unavailable" failure rather than silently
+    // falling through to plaintext.
+    throw new Error(
+      federated
+        ? `Cannot fetch pre-key bundle for federated user ${userId} — peer instance unreachable or has no bundle`
+        : `User ${userId} has no E2EE keys registered`
+    );
   }
 
   const typedBundle = bundle as PreKeyBundle;

--- a/apps/client/src/lib/e2ee/store.ts
+++ b/apps/client/src/lib/e2ee/store.ts
@@ -1,3 +1,38 @@
+/**
+ * Phase B / C / D — Signal Protocol IndexedDB store.
+ *
+ * Channels-vs-DMs scoping rule (clarified by Phase D / D2):
+ *
+ *   - **DMs always use the home store** (`signalStore`). The user
+ *     has one identity, used for all DM sessions regardless of
+ *     whether the recipient lives on this instance or a federated
+ *     peer. Cross-instance bundle exchange (Phase D / D1) goes
+ *     through `e2ee.getFederatedPreKeyBundle`; the resulting X3DH
+ *     session is keyed on the recipient's local shadow-user id and
+ *     stored in the home store next to same-instance sessions.
+ *     `verifiedIdentities` (TOFU pins) for DM peers also live in
+ *     the home store.
+ *
+ *   - **Server channels use the per-instance store**. When the user
+ *     is browsing a federated server, channel sender-key chains and
+ *     identity pins for that server's members live in
+ *     `getStoreForInstance(activeInstanceDomain)`. Each federated
+ *     server's identity context is independent.
+ *
+ *   - The chain-kind dispatch in encryptDmGroupMessage / decrypt
+ *     channel paths handles this — `KIND_DM` always routes to
+ *     `signalStore`, channel kinds route to `getActiveStore()`.
+ *
+ * Why split: same-instance and federated DMs are conceptually one
+ * conversation per peer; you don't want a different identity for
+ * Bob-on-remote.com vs Alice-on-home.com from your perspective.
+ * Server channels in contrast are server-local — your view of a
+ * federated server's encryption is server-scoped and shouldn't
+ * leak across instances. Phase C added the per-instance scaffolding
+ * for channels; Phase D / D2 codified that DMs deliberately bypass
+ * it.
+ */
+
 import { openDB, type IDBPDatabase } from 'idb';
 import type {
   Direction,

--- a/apps/server/src/db/migrations/0015_dm_federation_group_id.sql
+++ b/apps/server/src/db/migrations/0015_dm_federation_group_id.sql
@@ -1,0 +1,28 @@
+-- Phase D / D2 — federation-spanning identifier for group DMs that
+-- include members across instances. Only group DMs (`is_group=true`)
+-- with at least one federated member populate this column; same-
+-- instance groups and 1:1 DMs leave it NULL. Each peer instance's
+-- mirror channel for the same logical group has the same UUID, so
+-- inbound dm-relay (group messages) and dm-sender-key (SKDMs) can
+-- look up the local mirror by ID instead of trying to recompute
+-- "the group between these N members," which doesn't generalise
+-- across instances.
+--
+-- Idempotent: db/index.ts:27 wipes drizzle's migration tracking on
+-- every boot (pulse-issue-migration-pipeline), so the ALTER guards
+-- against re-execution.
+
+DO $$ BEGIN
+	ALTER TABLE "dm_channels" ADD COLUMN "federation_group_id" text;
+EXCEPTION
+	WHEN duplicate_column THEN null;
+END $$;
+--> statement-breakpoint
+
+-- Index for the dm-relay / dm-sender-key lookup path. Sparse — only
+-- federated groups have the column populated.
+DO $$ BEGIN
+	CREATE INDEX "dm_channels_federation_group_id_idx" ON "dm_channels" ("federation_group_id");
+EXCEPTION
+	WHEN duplicate_table THEN null;
+END $$;

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -662,20 +662,33 @@ const channelNotificationSettings = pgTable(
   ]
 );
 
-const dmChannels = pgTable('dm_channels', {
-  id: serial('id').primaryKey(),
-  name: text('name'),
-  ownerId: integer('owner_id').references(() => users.id, {
-    onDelete: 'set null'
-  }),
-  iconFileId: integer('icon_file_id').references(() => files.id, {
-    onDelete: 'set null'
-  }),
-  isGroup: boolean('is_group').notNull().default(false),
-  e2ee: boolean('e2ee').notNull().default(false),
-  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
-  updatedAt: bigint('updated_at', { mode: 'number' })
-});
+const dmChannels = pgTable(
+  'dm_channels',
+  {
+    id: serial('id').primaryKey(),
+    name: text('name'),
+    ownerId: integer('owner_id').references(() => users.id, {
+      onDelete: 'set null'
+    }),
+    iconFileId: integer('icon_file_id').references(() => files.id, {
+      onDelete: 'set null'
+    }),
+    isGroup: boolean('is_group').notNull().default(false),
+    e2ee: boolean('e2ee').notNull().default(false),
+    // Phase D / D2 — federation-spanning UUID for group DMs that
+    // include members from at least one other instance. Each peer
+    // instance's mirror channel for the same logical group carries
+    // the same value; dm-relay + dm-sender-key federation routes
+    // look up the local mirror by this column. Null for same-
+    // instance groups and all 1:1 DMs.
+    federationGroupId: text('federation_group_id'),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' })
+  },
+  (t) => [
+    index('dm_channels_federation_group_id_idx').on(t.federationGroupId)
+  ]
+);
 
 const dmChannelMembers = pgTable(
   'dm_channel_members',

--- a/apps/server/src/http/federation-dm-group.ts
+++ b/apps/server/src/http/federation-dm-group.ts
@@ -1,0 +1,547 @@
+/**
+ * Phase D / D2 — federation routes for cross-instance group DMs.
+ *
+ * Group DMs that span instances need a federation-spanning identifier
+ * (`federationGroupId`) because each instance has its own
+ * `dm_channels` row for the same logical group, and "find the shared
+ * group between users X, Y, Z" doesn't generalise once Y or Z lives
+ * on a different instance.
+ *
+ * The four handlers in this file mirror the lifecycle events that
+ * `dms/*` routes handle for same-instance groups:
+ *
+ *   - dm-group-create: announce a new group + members to a peer
+ *   - dm-group-add-member: notify a peer that a member was added
+ *   - dm-group-remove-member: notify a peer that a member was removed
+ *   - dm-sender-key: relay a per-recipient SKDM (E2EE bootstrap) to
+ *     a peer instance, where it lands in the local
+ *     dm_e2ee_sender_keys table for the recipient to fetch
+ *
+ * All four use the same wire-format hardening as existing federation
+ * routes (Phase 4 signed-body verification) and respond via D0's
+ * `signedJsonResponse` so the requester can authenticate the result
+ * past TLS-only protection.
+ */
+
+import { ServerEvents } from '@pulse/shared';
+import { and, eq } from 'drizzle-orm';
+import http from 'http';
+import { db } from '../db';
+import {
+  dmChannelMembers,
+  dmChannels,
+  dmE2eeSenderKeys,
+  federationInstances,
+  users
+} from '../db/schema';
+import { config } from '../config';
+import { findOrCreateShadowUser } from '../db/mutations/federation';
+import { logger } from '../logger';
+import { sanitizeForLog } from '../helpers/sanitize-for-log';
+import { pubsub } from '../utils/pubsub';
+import { signedJsonResponse, verifyChallenge } from '../utils/federation';
+
+type IncomingFederatedMember = {
+  publicId: string;
+  instanceDomain: string;
+  name: string;
+  avatarFile?: string | null;
+};
+
+const MAX_BODY_SIZE = 1024 * 1024;
+
+function parseBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const contentLength = parseInt(req.headers['content-length'] || '0', 10);
+    if (contentLength > MAX_BODY_SIZE) {
+      req.resume();
+      reject(new Error('Request body too large'));
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let totalSize = 0;
+    req.on('data', (chunk: Buffer) => {
+      totalSize += chunk.length;
+      if (totalSize > MAX_BODY_SIZE) {
+        req.destroy();
+        reject(new Error('Request body too large'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>);
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function jsonResponse(
+  res: http.ServerResponse,
+  status: number,
+  data: unknown
+) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+/**
+ * Common request prologue: enabled-check, parse body, look up the
+ * sender instance by `fromDomain`, verify the request signature.
+ * Returns `{ instance, signedBody, fromDomain }` on success or sends
+ * a 4xx and returns null.
+ */
+async function authorizeFederationRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+): Promise<
+  | {
+      instance: { id: number; publicKey: string; domain: string };
+      signedBody: Record<string, unknown>;
+      fromDomain: string;
+    }
+  | null
+> {
+  if (!config.federation.enabled) {
+    jsonResponse(res, 403, { error: 'Federation not enabled' });
+    return null;
+  }
+
+  const body = await parseBody(req);
+  const { signature, ...signedBody } = body as Record<string, unknown> & {
+    signature: string;
+  };
+  const fromDomain = signedBody.fromDomain as string;
+
+  if (!fromDomain || !signature || typeof signature !== 'string') {
+    jsonResponse(res, 400, { error: 'Missing fromDomain or signature' });
+    return null;
+  }
+
+  const [instance] = await db
+    .select()
+    .from(federationInstances)
+    .where(
+      and(
+        eq(federationInstances.domain, fromDomain),
+        eq(federationInstances.status, 'active')
+      )
+    )
+    .limit(1);
+
+  if (!instance || !instance.publicKey) {
+    jsonResponse(res, 403, { error: 'Not a trusted instance' });
+    return null;
+  }
+
+  const isValid = await verifyChallenge(
+    signature,
+    signedBody,
+    fromDomain,
+    instance.publicKey
+  );
+  if (!isValid) {
+    jsonResponse(res, 401, { error: 'Invalid signature' });
+    return null;
+  }
+
+  return {
+    instance: {
+      id: instance.id,
+      publicKey: instance.publicKey,
+      domain: instance.domain
+    },
+    signedBody,
+    fromDomain
+  };
+}
+
+/**
+ * Resolve a member descriptor to a local user id. Three cases:
+ *   1. Member's instanceDomain == our domain → find the local user
+ *      by publicId. Must already exist.
+ *   2. Member's instanceDomain == requesting peer's domain → use
+ *      `findOrCreateShadowUser` against that peer's instance row.
+ *   3. Member's instanceDomain is neither ours nor the requester's
+ *      → look up the third instance in our federationInstances
+ *      table; if active, create a shadow against it. If we don't
+ *      know the instance, return null (best-effort: this member
+ *      simply won't appear in our local mirror; messages routed
+ *      through them will fall back to the requesting peer being
+ *      able to see them).
+ */
+async function resolveMemberToLocalUserId(
+  member: IncomingFederatedMember,
+  requesterInstanceId: number,
+  requesterDomain: string
+): Promise<number | null> {
+  if (member.instanceDomain === config.federation.domain) {
+    const [localUser] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.publicId, member.publicId))
+      .limit(1);
+    return localUser?.id ?? null;
+  }
+
+  let instanceId: number;
+  if (member.instanceDomain === requesterDomain) {
+    instanceId = requesterInstanceId;
+  } else {
+    const [otherInstance] = await db
+      .select({ id: federationInstances.id, status: federationInstances.status })
+      .from(federationInstances)
+      .where(eq(federationInstances.domain, member.instanceDomain))
+      .limit(1);
+    if (!otherInstance || otherInstance.status !== 'active') {
+      logger.warn(
+        '[dm-group-create] skipping member from unfederated peer %s',
+        sanitizeForLog(member.instanceDomain)
+      );
+      return null;
+    }
+    instanceId = otherInstance.id;
+  }
+
+  const shadow = await findOrCreateShadowUser(
+    instanceId,
+    0,
+    member.name,
+    undefined,
+    member.publicId
+  );
+  return shadow.id;
+}
+
+// POST /federation/dm-group-create — receiver creates a local mirror
+// of the federated group identified by `federationGroupId`.
+const federationDmGroupCreateHandler = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  const auth = await authorizeFederationRequest(req, res);
+  if (!auth) return;
+  const { instance, signedBody, fromDomain } = auth;
+
+  const federationGroupId = signedBody.federationGroupId as string;
+  const name = (signedBody.name as string | null) ?? null;
+  const ownerPublicId = signedBody.ownerPublicId as string;
+  const members = signedBody.members as IncomingFederatedMember[];
+
+  if (
+    !federationGroupId ||
+    !ownerPublicId ||
+    !Array.isArray(members) ||
+    members.length === 0
+  ) {
+    return jsonResponse(res, 400, { error: 'Missing required fields' });
+  }
+
+  // Idempotent: a re-announce of the same group should be a no-op.
+  const [existing] = await db
+    .select({ id: dmChannels.id })
+    .from(dmChannels)
+    .where(eq(dmChannels.federationGroupId, federationGroupId))
+    .limit(1);
+
+  if (existing) {
+    return signedJsonResponse(res, 200, { alreadyExists: true }, fromDomain);
+  }
+
+  // Resolve every member to a local user id (real for our users,
+  // shadow for everyone else). Skip ones we can't resolve.
+  const memberIds: number[] = [];
+  const localRecipientIds: number[] = [];
+  let ownerId: number | null = null;
+
+  for (const member of members) {
+    const userId = await resolveMemberToLocalUserId(
+      member,
+      instance.id,
+      fromDomain
+    );
+    if (userId === null) continue;
+    memberIds.push(userId);
+    if (member.publicId === ownerPublicId) {
+      ownerId = userId;
+    }
+    if (member.instanceDomain === config.federation.domain) {
+      localRecipientIds.push(userId);
+    }
+  }
+
+  // We need at least one local member to bother creating the mirror —
+  // the whole point of mirroring is so our users can participate.
+  if (localRecipientIds.length === 0) {
+    return jsonResponse(res, 404, {
+      error: 'No local members in announced group'
+    });
+  }
+
+  const now = Date.now();
+  const [newChannel] = await db
+    .insert(dmChannels)
+    .values({
+      name,
+      ownerId,
+      isGroup: true,
+      federationGroupId,
+      createdAt: now
+    })
+    .returning();
+
+  await db.insert(dmChannelMembers).values(
+    memberIds.map((userId) => ({
+      dmChannelId: newChannel!.id,
+      userId,
+      createdAt: now
+    }))
+  );
+
+  for (const userId of localRecipientIds) {
+    pubsub.publishFor(userId, ServerEvents.DM_CHANNEL_UPDATE, {
+      dmChannelId: newChannel!.id,
+      name,
+      iconFileId: null
+    });
+  }
+
+  return signedJsonResponse(
+    res,
+    200,
+    { dmChannelId: newChannel!.id },
+    fromDomain
+  );
+};
+
+// POST /federation/dm-group-add-member — receiver adds the announced
+// member to the local mirror of the federated group.
+const federationDmGroupAddMemberHandler = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  const auth = await authorizeFederationRequest(req, res);
+  if (!auth) return;
+  const { instance, signedBody, fromDomain } = auth;
+
+  const federationGroupId = signedBody.federationGroupId as string;
+  const addedMember = signedBody.addedMember as
+    | IncomingFederatedMember
+    | undefined;
+
+  if (!federationGroupId || !addedMember?.publicId) {
+    return jsonResponse(res, 400, { error: 'Missing required fields' });
+  }
+
+  const [mirror] = await db
+    .select({ id: dmChannels.id })
+    .from(dmChannels)
+    .where(eq(dmChannels.federationGroupId, federationGroupId))
+    .limit(1);
+
+  if (!mirror) {
+    return jsonResponse(res, 404, { error: 'Group mirror not found' });
+  }
+
+  const userId = await resolveMemberToLocalUserId(
+    addedMember,
+    instance.id,
+    fromDomain
+  );
+
+  if (userId === null) {
+    // Best-effort: silently accept the add of a user we can't
+    // resolve (e.g. unfederated third-instance member). The message
+    // path will simply not surface their messages locally, which is
+    // the same as before.
+    return signedJsonResponse(res, 200, { skipped: true }, fromDomain);
+  }
+
+  // Idempotent: re-add of an existing member is a no-op.
+  const existingMembership = await db
+    .select({ userId: dmChannelMembers.userId })
+    .from(dmChannelMembers)
+    .where(
+      and(
+        eq(dmChannelMembers.dmChannelId, mirror.id),
+        eq(dmChannelMembers.userId, userId)
+      )
+    )
+    .limit(1);
+
+  if (existingMembership.length === 0) {
+    await db.insert(dmChannelMembers).values({
+      dmChannelId: mirror.id,
+      userId,
+      createdAt: Date.now()
+    });
+  }
+
+  // Notify all local members
+  const allMembers = await db
+    .select({ userId: dmChannelMembers.userId })
+    .from(dmChannelMembers)
+    .where(eq(dmChannelMembers.dmChannelId, mirror.id));
+
+  for (const m of allMembers) {
+    pubsub.publishFor(m.userId, ServerEvents.DM_MEMBER_ADD, {
+      dmChannelId: mirror.id,
+      userId
+    });
+  }
+
+  return signedJsonResponse(res, 200, { dmChannelId: mirror.id }, fromDomain);
+};
+
+// POST /federation/dm-group-remove-member — receiver removes the
+// announced member from the local mirror.
+const federationDmGroupRemoveMemberHandler = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  const auth = await authorizeFederationRequest(req, res);
+  if (!auth) return;
+  const { signedBody, fromDomain } = auth;
+
+  const federationGroupId = signedBody.federationGroupId as string;
+  const removedPublicId = signedBody.removedPublicId as string;
+
+  if (!federationGroupId || !removedPublicId) {
+    return jsonResponse(res, 400, { error: 'Missing required fields' });
+  }
+
+  const [mirror] = await db
+    .select({ id: dmChannels.id })
+    .from(dmChannels)
+    .where(eq(dmChannels.federationGroupId, federationGroupId))
+    .limit(1);
+
+  if (!mirror) {
+    return jsonResponse(res, 404, { error: 'Group mirror not found' });
+  }
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.publicId, removedPublicId))
+    .limit(1);
+
+  if (!user) {
+    // Already gone or never resolved locally — idempotent success.
+    return signedJsonResponse(res, 200, { skipped: true }, fromDomain);
+  }
+
+  const allMembersBeforeDelete = await db
+    .select({ userId: dmChannelMembers.userId })
+    .from(dmChannelMembers)
+    .where(eq(dmChannelMembers.dmChannelId, mirror.id));
+
+  await db
+    .delete(dmChannelMembers)
+    .where(
+      and(
+        eq(dmChannelMembers.dmChannelId, mirror.id),
+        eq(dmChannelMembers.userId, user.id)
+      )
+    );
+
+  for (const m of allMembersBeforeDelete) {
+    pubsub.publishFor(m.userId, ServerEvents.DM_MEMBER_REMOVE, {
+      dmChannelId: mirror.id,
+      userId: user.id
+    });
+  }
+
+  return signedJsonResponse(res, 200, { dmChannelId: mirror.id }, fromDomain);
+};
+
+// POST /federation/dm-sender-key — receiver records a per-recipient
+// SKDM (sender-key distribution message) addressed to one of our
+// local users. Mirrors `dms.distributeSenderKeys` writes for the
+// federated case.
+const federationDmSenderKeyHandler = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  const auth = await authorizeFederationRequest(req, res);
+  if (!auth) return;
+  const { instance, signedBody, fromDomain } = auth;
+
+  const federationGroupId = signedBody.federationGroupId as string;
+  const senderKeyId = signedBody.senderKeyId as number;
+  const fromPublicId = signedBody.fromPublicId as string;
+  const toPublicId = signedBody.toPublicId as string;
+  const distributionMessage = signedBody.distributionMessage as string;
+
+  if (
+    !federationGroupId ||
+    typeof senderKeyId !== 'number' ||
+    !fromPublicId ||
+    !toPublicId ||
+    !distributionMessage
+  ) {
+    return jsonResponse(res, 400, { error: 'Missing required fields' });
+  }
+
+  const [mirror] = await db
+    .select({ id: dmChannels.id })
+    .from(dmChannels)
+    .where(eq(dmChannels.federationGroupId, federationGroupId))
+    .limit(1);
+
+  if (!mirror) {
+    return jsonResponse(res, 404, { error: 'Group mirror not found' });
+  }
+
+  // Sender lives on the requesting peer's instance; resolve via shadow.
+  const shadowSender = await findOrCreateShadowUser(
+    instance.id,
+    0,
+    fromPublicId,
+    undefined,
+    fromPublicId
+  );
+
+  // Recipient must be local.
+  const [localRecipient] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.publicId, toPublicId))
+    .limit(1);
+
+  if (!localRecipient) {
+    return jsonResponse(res, 404, { error: 'Local recipient not found' });
+  }
+
+  await db.insert(dmE2eeSenderKeys).values({
+    dmChannelId: mirror.id,
+    senderKeyId,
+    fromUserId: shadowSender.id,
+    toUserId: localRecipient.id,
+    distributionMessage,
+    createdAt: Date.now()
+  });
+
+  pubsub.publishFor(
+    localRecipient.id,
+    ServerEvents.DM_SENDER_KEY_DISTRIBUTION,
+    {
+      dmChannelId: mirror.id,
+      fromUserId: shadowSender.id
+    }
+  );
+
+  return signedJsonResponse(res, 200, { success: true }, fromDomain);
+};
+
+export {
+  federationDmGroupAddMemberHandler,
+  federationDmGroupCreateHandler,
+  federationDmGroupRemoveMemberHandler,
+  federationDmSenderKeyHandler
+};

--- a/apps/server/src/http/federation.ts
+++ b/apps/server/src/http/federation.ts
@@ -834,6 +834,14 @@ const federationDmRelayHandler = async (
   // defaults false to preserve the pre-Phase-D plaintext behaviour
   // for in-flight v0.2 traffic.
   const isE2ee = signedBody.e2ee === true;
+  // Phase D / D2 — populated for group DMs that span instances. The
+  // receiving instance looks up its local mirror by this ID instead
+  // of `findDmChannelBetween` (which is hardcoded to 1:1). Null /
+  // undefined for 1:1 DMs and same-instance groups.
+  const federationGroupId =
+    typeof signedBody.federationGroupId === 'string'
+      ? signedBody.federationGroupId
+      : null;
 
   if (!fromDomain || !fromUsername || !content || !signature) {
     return jsonResponse(res, 400, { error: 'Missing required fields' });
@@ -897,15 +905,40 @@ const federationDmRelayHandler = async (
     return jsonResponse(res, 404, { error: 'Local user not found' });
   }
 
-  // Find or create DM channel between shadow user and local user
+  // Find or create DM channel between shadow user and local user.
+  // Phase D / D2 — for group DMs the sender includes a
+  // `federationGroupId` and we look up the local mirror channel by
+  // that column instead of `findDmChannelBetween` (which is
+  // hardcoded to 1:1 and would otherwise route group messages into
+  // a brand-new 1:1 channel).
   const { findDmChannelBetween, getDmMessage } = await import('../db/queries/dms');
   const { dmChannels, dmChannelMembers, dmMessages } = await import('../db/schema');
 
-  let dmChannelId = await findDmChannelBetween(shadowUser.id, localUser.id);
+  let dmChannelId: number | null = null;
+  if (federationGroupId) {
+    const [mirror] = await db
+      .select({ id: dmChannels.id })
+      .from(dmChannels)
+      .where(eq(dmChannels.federationGroupId, federationGroupId))
+      .limit(1);
+    dmChannelId = mirror?.id ?? null;
+    if (!dmChannelId) {
+      // The peer must announce the group via /federation/dm-group-
+      // create before relaying messages. If we never received that
+      // announcement (or it was lost), refuse the message rather
+      // than silently routing into a wrong 1:1 channel.
+      return jsonResponse(res, 404, {
+        error: 'Group mirror not found — was the group announced first?'
+      });
+    }
+  } else {
+    dmChannelId = await findDmChannelBetween(shadowUser.id, localUser.id);
+  }
+
   let channelE2eeFlipped = false;
 
   if (!dmChannelId) {
-    // New channel — initialise its e2ee flag from the incoming envelope.
+    // New 1:1 channel — initialise its e2ee flag from the incoming envelope.
     const [newChannel] = await db
       .insert(dmChannels)
       .values({ createdAt: Date.now(), e2ee: isE2ee })

--- a/apps/server/src/http/index.ts
+++ b/apps/server/src/http/index.ts
@@ -18,6 +18,12 @@ import {
   federationServersHandler,
   federationUserInfoHandler
 } from './federation';
+import {
+  federationDmGroupAddMemberHandler,
+  federationDmGroupCreateHandler,
+  federationDmGroupRemoveMemberHandler,
+  federationDmSenderKeyHandler
+} from './federation-dm-group';
 import { healthRouteHandler } from './healthz';
 import { infoRouteHandler } from './info';
 import { interfaceRouteHandler } from './interface';
@@ -129,6 +135,26 @@ const createHttpServer = async (port: number = config.server.port) => {
           if (req.method === 'POST' && req.url === '/federation/get-prekey-bundle') {
             if (!checkRateLimit(req, res, federationRateLimit)) return;
             return await federationGetPreKeyBundleHandler(req, res);
+          }
+
+          if (req.method === 'POST' && req.url === '/federation/dm-group-create') {
+            if (!checkRateLimit(req, res, federationRateLimit)) return;
+            return await federationDmGroupCreateHandler(req, res);
+          }
+
+          if (req.method === 'POST' && req.url === '/federation/dm-group-add-member') {
+            if (!checkRateLimit(req, res, federationRateLimit)) return;
+            return await federationDmGroupAddMemberHandler(req, res);
+          }
+
+          if (req.method === 'POST' && req.url === '/federation/dm-group-remove-member') {
+            if (!checkRateLimit(req, res, federationRateLimit)) return;
+            return await federationDmGroupRemoveMemberHandler(req, res);
+          }
+
+          if (req.method === 'POST' && req.url === '/federation/dm-sender-key') {
+            if (!checkRateLimit(req, res, federationRateLimit)) return;
+            return await federationDmSenderKeyHandler(req, res);
           }
 
           if (req.method === 'POST' && req.url === '/federation/report-user') {

--- a/apps/server/src/routers/dms/add-member.ts
+++ b/apps/server/src/routers/dms/add-member.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 import { db } from '../../db';
 import { getDmChannelMemberIds } from '../../db/queries/dms';
 import { dmChannelMembers, dmChannels, friendships } from '../../db/schema';
+import {
+  announceFederatedGroupAddMember,
+  announceFederatedGroupCreate,
+  assignFederationGroupIdIfNeeded
+} from '../../utils/federation-dm-group-dispatch';
 import { invariant } from '../../utils/invariant';
 import { pubsub } from '../../utils/pubsub';
 import { protectedProcedure } from '../../utils/trpc';
@@ -144,6 +149,31 @@ const addMemberRoute = protectedProcedure
           dmChannelId: input.dmChannelId,
           userId: addedId
         });
+      }
+    }
+
+    // Phase D / D2 — federation propagation. Two cases:
+    //  1. 1:1 → group promotion that adds a federated member, OR a
+    //     same-instance group that's gaining its first federated
+    //     member. The channel doesn't have a federationGroupId yet —
+    //     assign one, then announce the whole group to peers (they
+    //     need the full member list, not just the add-member event).
+    //  2. Existing federated group gaining a member. Just dispatch
+    //     dm-group-add-member to peers.
+    const channelHadFederationId = !!channel.federationGroupId;
+    const federationGroupId = await assignFederationGroupIdIfNeeded(
+      input.dmChannelId
+    );
+    if (federationGroupId) {
+      if (!channelHadFederationId) {
+        void announceFederatedGroupCreate(
+          input.dmChannelId,
+          channel.ownerId ?? ctx.userId
+        );
+      } else {
+        for (const addedId of toAdd) {
+          void announceFederatedGroupAddMember(input.dmChannelId, addedId);
+        }
       }
     }
   });

--- a/apps/server/src/routers/dms/create-group.ts
+++ b/apps/server/src/routers/dms/create-group.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 import { db } from '../../db';
 import { getDmChannelsForUser } from '../../db/queries/dms';
 import { dmChannelMembers, dmChannels, friendships } from '../../db/schema';
+import {
+  announceFederatedGroupCreate,
+  assignFederationGroupIdIfNeeded
+} from '../../utils/federation-dm-group-dispatch';
 import { pubsub } from '../../utils/pubsub';
 import { protectedProcedure } from '../../utils/trpc';
 
@@ -76,6 +80,17 @@ const createGroupRoute = protectedProcedure
         name: channel!.name,
         iconFileId: null
       });
+    }
+
+    // Phase D / D2 — if any member is federated, assign a
+    // federationGroupId and announce the group to every involved
+    // peer instance so each builds a local mirror channel keyed by
+    // that ID. Best-effort; a failed peer announcement leaves the
+    // local group functional and the peer can still receive
+    // messages once they catch up via re-announce on next message.
+    const federationGroupId = await assignFederationGroupIdIfNeeded(channel!.id);
+    if (federationGroupId) {
+      void announceFederatedGroupCreate(channel!.id, ctx.userId);
     }
 
     const channels = await getDmChannelsForUser(ctx.userId);

--- a/apps/server/src/routers/dms/remove-member.ts
+++ b/apps/server/src/routers/dms/remove-member.ts
@@ -3,7 +3,8 @@ import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
 import { getDmChannelMemberIds } from '../../db/queries/dms';
-import { dmChannelMembers, dmChannels } from '../../db/schema';
+import { dmChannelMembers, dmChannels, users } from '../../db/schema';
+import { announceFederatedGroupRemoveMember } from '../../utils/federation-dm-group-dispatch';
 import { pubsub } from '../../utils/pubsub';
 import { protectedProcedure } from '../../utils/trpc';
 
@@ -40,6 +41,21 @@ const removeMemberRoute = protectedProcedure
       ctx.throwValidationError('userId', 'User is not a member');
     }
 
+    // Capture the removed user's federated publicId BEFORE deleting,
+    // so we have it for the federation announcement below.
+    const [removedUser] = await db
+      .select({
+        publicId: users.publicId,
+        isFederated: users.isFederated,
+        federatedPublicId: users.federatedPublicId
+      })
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .limit(1);
+    const removedPublicId = removedUser?.isFederated
+      ? removedUser.federatedPublicId ?? removedUser.publicId
+      : removedUser?.publicId ?? null;
+
     await db
       .delete(dmChannelMembers)
       .where(
@@ -55,6 +71,15 @@ const removeMemberRoute = protectedProcedure
         dmChannelId: input.dmChannelId,
         userId: input.userId
       });
+    }
+
+    // Phase D / D2 — federation propagation for federated groups.
+    if (channel.federationGroupId && removedPublicId) {
+      void announceFederatedGroupRemoveMember(
+        input.dmChannelId,
+        input.userId,
+        removedPublicId
+      );
     }
   });
 

--- a/apps/server/src/routers/dms/send-message.ts
+++ b/apps/server/src/routers/dms/send-message.ts
@@ -8,6 +8,7 @@ import { getUserById } from '../../db/queries/users';
 import { dmChannels, dmMessageFiles, dmMessages, federationInstances } from '../../db/schema';
 import { enqueueProcessDmMetadata } from '../../queues/dm-message-metadata';
 import { relayToInstance } from '../../utils/federation';
+import { getFederationGroupId } from '../../utils/federation-dm-group-dispatch';
 import { invariant } from '../../utils/invariant';
 import { fileManager } from '../../utils/file-manager';
 import { logger } from '../../logger';
@@ -125,8 +126,14 @@ const sendMessageRoute = protectedProcedure
     // The receiving instance never decrypts; it just routes the
     // ciphertext to the recipient's WS and persists with e2ee=true.
     // Plaintext path is unchanged.
+    //
+    // Phase D / D2 — for group DMs that span instances we include
+    // the channel's `federationGroupId` so the receiver can route
+    // the message into the correct mirror channel instead of the
+    // 1:1 fallback.
     if (input.content) {
       const sender = await getUserById(ctx.userId);
+      const federationGroupId = await getFederationGroupId(input.dmChannelId);
       if (sender) {
         for (const memberId of memberIds) {
           if (memberId === ctx.userId) continue;
@@ -158,7 +165,10 @@ const sendMessageRoute = protectedProcedure
                 // Phase D / D1: receiver uses this flag to persist
                 // the message with e2ee=true and to auto-upgrade the
                 // channel's encryption flag on first ciphertext.
-                e2ee: isE2ee
+                e2ee: isE2ee,
+                // Phase D / D2: only set for federated group DMs.
+                // Receiver looks up the mirror channel by this id.
+                ...(federationGroupId ? { federationGroupId } : {})
               }).catch((err) =>
                 logger.error('[sendDmMessage] federation relay failed: %o', err)
               );

--- a/apps/server/src/routers/dms/sender-keys.ts
+++ b/apps/server/src/routers/dms/sender-keys.ts
@@ -1,10 +1,17 @@
 import { ServerEvents } from '@pulse/shared';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
 import { getDmChannelMemberIds } from '../../db/queries/dms';
-import { dmE2eeSenderKeys } from '../../db/schema';
+import { dmE2eeSenderKeys, users } from '../../db/schema';
+import {
+  announceFederatedGroupCreate,
+  assignFederationGroupIdIfNeeded,
+  getFederationGroupId,
+  relayFederatedSkdm
+} from '../../utils/federation-dm-group-dispatch';
 import { invariant } from '../../utils/invariant';
+import { logger } from '../../logger';
 import { pubsub } from '../../utils/pubsub';
 import { protectedProcedure, userSubscription } from '../../utils/trpc';
 
@@ -46,22 +53,85 @@ const distributeSenderKeysRoute = protectedProcedure
       });
     }
 
-    await db.insert(dmE2eeSenderKeys).values(
-      input.distributions.map((d) => ({
-        dmChannelId: input.dmChannelId,
-        senderKeyId: input.senderKeyId,
-        fromUserId: ctx.userId,
-        toUserId: d.toUserId,
-        distributionMessage: d.distributionMessage,
-        createdAt: Date.now()
-      }))
+    // Phase D / D2 — split distributions into local vs federated.
+    // Local recipients get the SKDM stored on this server (existing
+    // behaviour). Federated recipients have their SKDM relayed to
+    // their home instance via /federation/dm-sender-key, where it
+    // lands in that instance's local dm_e2ee_sender_keys for the
+    // recipient to fetch. Without this split, federated recipients
+    // never see the SKDM (their client polls their home instance,
+    // not ours), so group decryption breaks for them.
+    const recipientUserIds = input.distributions.map((d) => d.toUserId);
+    const recipientRows = await db
+      .select({
+        id: users.id,
+        isFederated: users.isFederated
+      })
+      .from(users)
+      .where(inArray(users.id, recipientUserIds));
+    const isFederatedById = new Map(
+      recipientRows.map((r) => [r.id, r.isFederated])
     );
 
-    for (const d of input.distributions) {
-      pubsub.publishFor(d.toUserId, ServerEvents.DM_SENDER_KEY_DISTRIBUTION, {
-        dmChannelId: input.dmChannelId,
-        fromUserId: ctx.userId
-      });
+    const localDists = input.distributions.filter(
+      (d) => !isFederatedById.get(d.toUserId)
+    );
+    const federatedDists = input.distributions.filter(
+      (d) => isFederatedById.get(d.toUserId) === true
+    );
+
+    if (localDists.length > 0) {
+      await db.insert(dmE2eeSenderKeys).values(
+        localDists.map((d) => ({
+          dmChannelId: input.dmChannelId,
+          senderKeyId: input.senderKeyId,
+          fromUserId: ctx.userId,
+          toUserId: d.toUserId,
+          distributionMessage: d.distributionMessage,
+          createdAt: Date.now()
+        }))
+      );
+
+      for (const d of localDists) {
+        pubsub.publishFor(d.toUserId, ServerEvents.DM_SENDER_KEY_DISTRIBUTION, {
+          dmChannelId: input.dmChannelId,
+          fromUserId: ctx.userId
+        });
+      }
+    }
+
+    if (federatedDists.length > 0) {
+      // Self-heal for groups that pre-date Phase D / D2: assign a
+      // federationGroupId on the fly and re-announce so peers build
+      // their mirrors. New groups created via createGroup already
+      // have the id set; this only fires for legacy rows that gained
+      // federated members before the column existed.
+      let federationGroupId = await getFederationGroupId(input.dmChannelId);
+      if (!federationGroupId) {
+        federationGroupId = await assignFederationGroupIdIfNeeded(
+          input.dmChannelId
+        );
+        if (federationGroupId) {
+          void announceFederatedGroupCreate(input.dmChannelId, ctx.userId);
+        }
+      }
+
+      if (!federationGroupId) {
+        logger.warn(
+          '[distributeDmSenderKeys] channel %s has federated recipients but federationGroupId could not be assigned',
+          input.dmChannelId
+        );
+      } else {
+        for (const d of federatedDists) {
+          void relayFederatedSkdm({
+            federationGroupId,
+            senderKeyId: input.senderKeyId,
+            fromUserId: ctx.userId,
+            toUserId: d.toUserId,
+            distributionMessage: d.distributionMessage
+          });
+        }
+      }
     }
   });
 

--- a/apps/server/src/routers/e2ee/get-federated-prekey-bundle.ts
+++ b/apps/server/src/routers/e2ee/get-federated-prekey-bundle.ts
@@ -1,41 +1,67 @@
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { config } from '../../config';
+import { db } from '../../db';
+import { federationInstances, users } from '../../db/schema';
 import { queryInstance } from '../../utils/federation';
 import { protectedProcedure } from '../../utils/trpc';
 
 /**
- * Fetch a pre-key bundle for a user on a federated peer instance.
- * Phase D / D1.
+ * Fetch a pre-key bundle for a federated user. Phase D / D1.
  *
- * Calls the remote peer's `POST /federation/get-prekey-bundle` via
- * `queryInstance`, which signs the request and verifies the signed
- * response against the peer's stored federation public key. Returns
- * the verified bundle on success, or `null` on any failure (peer
- * offline, signature invalid, peer unknown, target user not found,
- * pool exhausted with no signed pre-key, etc).
+ * Input is the local shadow-user id, which the home server resolves
+ * into the federated identifiers (`federatedInstanceId` →
+ * `instanceDomain`, `federatedPublicId`) before calling the peer's
+ * `POST /federation/get-prekey-bundle` via `queryInstance`. The
+ * response is signature-verified against the peer's stored
+ * federation public key (Phase D / D0).
  *
- * The route is intentionally minimal — no application-level
- * authorization beyond `protectedProcedure`. Federation hardening
- * (peer rate-limit, DNS revalidation, body cap, signature
- * verification) is layered in the underlying helpers. The peer side
- * separately enforces a per-publicId rate limit to protect its OTPK
- * pools.
+ * Returns the verified bundle on success, or `null` on any failure
+ * (peer offline, signature invalid, peer unknown, target user has
+ * no bundle, target is not actually a federated user, etc.). Per
+ * Decision 2, the caller surfaces null as a hard "encrypted DM
+ * unavailable" failure — there is no silent fallback to plaintext.
  *
  * Returned shape mirrors the same-instance `e2ee.getPreKeyBundle`
  * route plus a `fromDomain` field that the response signature is
- * bound to (the responding instance's own domain). Callers can
- * ignore `fromDomain`; it's there so the verifier had something to
- * commit to as part of the digest.
+ * bound to. Callers can ignore `fromDomain`; it's present so the
+ * verifier had something to commit to as part of the digest.
  */
 const getFederatedPreKeyBundleRoute = protectedProcedure
-  .input(
-    z.object({
-      instanceDomain: z.string().min(1),
-      targetPublicId: z.string().min(1)
-    })
-  )
+  .input(z.object({ userId: z.number() }))
   .query(async ({ input }) => {
     if (!config.federation.enabled) {
+      return null;
+    }
+
+    const [user] = await db
+      .select({
+        isFederated: users.isFederated,
+        federatedInstanceId: users.federatedInstanceId,
+        federatedPublicId: users.federatedPublicId
+      })
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .limit(1);
+
+    if (
+      !user?.isFederated ||
+      !user.federatedInstanceId ||
+      !user.federatedPublicId
+    ) {
+      return null;
+    }
+
+    const [instance] = await db
+      .select({
+        domain: federationInstances.domain,
+        status: federationInstances.status
+      })
+      .from(federationInstances)
+      .where(eq(federationInstances.id, user.federatedInstanceId))
+      .limit(1);
+
+    if (!instance || instance.status !== 'active') {
       return null;
     }
 
@@ -56,9 +82,9 @@ const getFederatedPreKeyBundleRoute = protectedProcedure
     };
 
     const result = await queryInstance<FederatedBundle>(
-      input.instanceDomain,
+      instance.domain,
       '/federation/get-prekey-bundle',
-      { targetPublicId: input.targetPublicId }
+      { targetPublicId: user.federatedPublicId }
     );
 
     return result;

--- a/apps/server/src/utils/__tests__/federation-dm-group-dispatch.test.ts
+++ b/apps/server/src/utils/__tests__/federation-dm-group-dispatch.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Phase D / D2 — federation-dm-group-dispatch unit tests.
+ *
+ * Covers the pure-DB helpers that decide whether and how to relay
+ * group DM lifecycle events to peer instances. Network-side
+ * (`relayToInstance`) is fire-and-forget; tested elsewhere.
+ *
+ *   - `assignFederationGroupIdIfNeeded` — assigns a UUID when a
+ *     group has any federated member; returns null otherwise; is
+ *     idempotent.
+ *   - `buildFederatedMemberList` — returns the wire-shape member
+ *     list with correct local-vs-federated domain attribution and
+ *     a complete set of peer domains.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db } from '../../db';
+import {
+  dmChannelMembers,
+  dmChannels,
+  federationInstances,
+  users
+} from '../../db/schema';
+import { initTest } from '../../__tests__/helpers';
+import { config } from '../../config';
+import {
+  assignFederationGroupIdIfNeeded,
+  buildFederatedMemberList
+} from '../federation-dm-group-dispatch';
+
+const PEER_DOMAIN_A = 'peer-a.example';
+const PEER_DOMAIN_B = 'peer-b.example';
+
+let federatedInstanceAId: number;
+let federatedInstanceBId: number;
+let localUserId: number;
+let federatedUserAId: number;
+let federatedUserBId: number;
+
+beforeEach(async () => {
+  await initTest();
+
+  const [instA] = await db
+    .insert(federationInstances)
+    .values({
+      domain: PEER_DOMAIN_A,
+      name: 'Peer A',
+      status: 'active',
+      direction: 'outgoing',
+      createdAt: Date.now()
+    })
+    .returning();
+  federatedInstanceAId = instA!.id;
+
+  const [instB] = await db
+    .insert(federationInstances)
+    .values({
+      domain: PEER_DOMAIN_B,
+      name: 'Peer B',
+      status: 'active',
+      direction: 'outgoing',
+      createdAt: Date.now()
+    })
+    .returning();
+  federatedInstanceBId = instB!.id;
+
+  // initTest seeded user 1 (test owner). We add another local user
+  // and two federated shadow users.
+  localUserId = 1;
+
+  const [fedA] = await db
+    .insert(users)
+    .values({
+      supabaseId: 'fed-a-uuid',
+      name: 'fedAlice',
+      publicId: 'fed-a-public',
+      isFederated: true,
+      federatedInstanceId: federatedInstanceAId,
+      federatedPublicId: 'remote-a-pid',
+      createdAt: Date.now()
+    })
+    .returning();
+  federatedUserAId = fedA!.id;
+
+  const [fedB] = await db
+    .insert(users)
+    .values({
+      supabaseId: 'fed-b-uuid',
+      name: 'fedBob',
+      publicId: 'fed-b-public',
+      isFederated: true,
+      federatedInstanceId: federatedInstanceBId,
+      federatedPublicId: 'remote-b-pid',
+      createdAt: Date.now()
+    })
+    .returning();
+  federatedUserBId = fedB!.id;
+});
+
+afterEach(() => {
+  // initTest's beforeEach truncates everything before the next test;
+  // nothing to do here.
+});
+
+async function createChannel(args: {
+  isGroup: boolean;
+  memberIds: number[];
+  federationGroupId?: string | null;
+}): Promise<number> {
+  const [channel] = await db
+    .insert(dmChannels)
+    .values({
+      isGroup: args.isGroup,
+      federationGroupId: args.federationGroupId ?? null,
+      createdAt: Date.now()
+    })
+    .returning();
+  await db.insert(dmChannelMembers).values(
+    args.memberIds.map((userId) => ({
+      dmChannelId: channel!.id,
+      userId,
+      createdAt: Date.now()
+    }))
+  );
+  return channel!.id;
+}
+
+describe('assignFederationGroupIdIfNeeded', () => {
+  test('returns null for a same-instance group', async () => {
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [localUserId]
+    });
+    const result = await assignFederationGroupIdIfNeeded(channelId);
+    expect(result).toBeNull();
+    const [row] = await db
+      .select({ federationGroupId: dmChannels.federationGroupId })
+      .from(dmChannels)
+      .where(eq(dmChannels.id, channelId));
+    expect(row?.federationGroupId).toBeNull();
+  });
+
+  test('returns null for a 1:1 channel even with a federated member', async () => {
+    // 1:1 channels never get a federationGroupId — Phase D / D2 only
+    // applies to groups (the column is null for 1:1s by design).
+    const channelId = await createChannel({
+      isGroup: false,
+      memberIds: [localUserId, federatedUserAId]
+    });
+    const result = await assignFederationGroupIdIfNeeded(channelId);
+    expect(result).toBeNull();
+  });
+
+  test('assigns a UUID when a group includes any federated member', async () => {
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [localUserId, federatedUserAId]
+    });
+    const result = await assignFederationGroupIdIfNeeded(channelId);
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe('string');
+    expect(result!.length).toBeGreaterThan(0);
+
+    // The id is persisted to the row.
+    const [row] = await db
+      .select({ federationGroupId: dmChannels.federationGroupId })
+      .from(dmChannels)
+      .where(eq(dmChannels.id, channelId));
+    expect(row?.federationGroupId).toBe(result);
+  });
+
+  test('is idempotent — a second call returns the same value', async () => {
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [localUserId, federatedUserAId]
+    });
+    const first = await assignFederationGroupIdIfNeeded(channelId);
+    const second = await assignFederationGroupIdIfNeeded(channelId);
+    expect(second).toBe(first);
+  });
+});
+
+describe('buildFederatedMemberList', () => {
+  test('attributes local users to our domain and federated users to their home', async () => {
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [localUserId, federatedUserAId, federatedUserBId]
+    });
+    const { members, peerDomains } = await buildFederatedMemberList(channelId);
+
+    expect(members).toHaveLength(3);
+    const localMember = members.find(
+      (m) => m.instanceDomain === config.federation.domain
+    );
+    expect(localMember).toBeDefined();
+
+    const aMember = members.find((m) => m.instanceDomain === PEER_DOMAIN_A);
+    expect(aMember).toBeDefined();
+    expect(aMember!.publicId).toBe('remote-a-pid');
+
+    const bMember = members.find((m) => m.instanceDomain === PEER_DOMAIN_B);
+    expect(bMember).toBeDefined();
+    expect(bMember!.publicId).toBe('remote-b-pid');
+
+    expect(peerDomains.has(PEER_DOMAIN_A)).toBe(true);
+    expect(peerDomains.has(PEER_DOMAIN_B)).toBe(true);
+    expect(peerDomains.size).toBe(2);
+  });
+
+  test('returns the federated public id (not the local shadow publicId)', async () => {
+    // The shadow user has `publicId` (assigned by the local instance)
+    // and `federatedPublicId` (the user's id at their home). The
+    // wire-shape member descriptor has to use the federated one so
+    // peers can match.
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [federatedUserAId]
+    });
+    const { members } = await buildFederatedMemberList(channelId);
+    const fedA = members.find((m) => m.instanceDomain === PEER_DOMAIN_A);
+    expect(fedA!.publicId).toBe('remote-a-pid');
+    expect(fedA!.publicId).not.toBe('fed-a-public');
+  });
+
+  test('peerDomains is empty for an all-local group', async () => {
+    const channelId = await createChannel({
+      isGroup: true,
+      memberIds: [localUserId]
+    });
+    const { peerDomains } = await buildFederatedMemberList(channelId);
+    expect(peerDomains.size).toBe(0);
+  });
+});

--- a/apps/server/src/utils/__tests__/federation-dm-group-dispatch.test.ts
+++ b/apps/server/src/utils/__tests__/federation-dm-group-dispatch.test.ts
@@ -11,9 +11,16 @@
  *   - `buildFederatedMemberList` — returns the wire-shape member
  *     list with correct local-vs-federated domain attribution and
  *     a complete set of peer domains.
+ *
+ * Setup is done inside each test rather than in beforeEach. Following
+ * the federation-membership.test.ts pattern: avoids piling rows onto
+ * the shared CI postgres in a beforeEach hook that competes with
+ * other test files' TRUNCATE in setup.ts and triggers cross-file
+ * deadlock timeouts (see pulse-build-bun-stale-symlinks +
+ * federation-rate-limit notes for the same class of issue).
  */
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import {
@@ -22,7 +29,6 @@ import {
   federationInstances,
   users
 } from '../../db/schema';
-import { initTest } from '../../__tests__/helpers';
 import { config } from '../../config';
 import {
   assignFederationGroupIdIfNeeded,
@@ -32,15 +38,11 @@ import {
 const PEER_DOMAIN_A = 'peer-a.example';
 const PEER_DOMAIN_B = 'peer-b.example';
 
-let federatedInstanceAId: number;
-let federatedInstanceBId: number;
-let localUserId: number;
-let federatedUserAId: number;
-let federatedUserBId: number;
-
-beforeEach(async () => {
-  await initTest();
-
+/**
+ * Seed two federation peers and two shadow users, returning their
+ * ids. Local user 1 is provided by the global seed.ts setup.
+ */
+async function seedFederatedScenario() {
   const [instA] = await db
     .insert(federationInstances)
     .values({
@@ -51,7 +53,6 @@ beforeEach(async () => {
       createdAt: Date.now()
     })
     .returning();
-  federatedInstanceAId = instA!.id;
 
   const [instB] = await db
     .insert(federationInstances)
@@ -63,11 +64,6 @@ beforeEach(async () => {
       createdAt: Date.now()
     })
     .returning();
-  federatedInstanceBId = instB!.id;
-
-  // initTest seeded user 1 (test owner). We add another local user
-  // and two federated shadow users.
-  localUserId = 1;
 
   const [fedA] = await db
     .insert(users)
@@ -76,12 +72,11 @@ beforeEach(async () => {
       name: 'fedAlice',
       publicId: 'fed-a-public',
       isFederated: true,
-      federatedInstanceId: federatedInstanceAId,
+      federatedInstanceId: instA!.id,
       federatedPublicId: 'remote-a-pid',
       createdAt: Date.now()
     })
     .returning();
-  federatedUserAId = fedA!.id;
 
   const [fedB] = await db
     .insert(users)
@@ -90,18 +85,20 @@ beforeEach(async () => {
       name: 'fedBob',
       publicId: 'fed-b-public',
       isFederated: true,
-      federatedInstanceId: federatedInstanceBId,
+      federatedInstanceId: instB!.id,
       federatedPublicId: 'remote-b-pid',
       createdAt: Date.now()
     })
     .returning();
-  federatedUserBId = fedB!.id;
-});
 
-afterEach(() => {
-  // initTest's beforeEach truncates everything before the next test;
-  // nothing to do here.
-});
+  return {
+    localUserId: 1,
+    federatedUserAId: fedA!.id,
+    federatedUserBId: fedB!.id,
+    instAId: instA!.id,
+    instBId: instB!.id
+  };
+}
 
 async function createChannel(args: {
   isGroup: boolean;
@@ -128,6 +125,7 @@ async function createChannel(args: {
 
 describe('assignFederationGroupIdIfNeeded', () => {
   test('returns null for a same-instance group', async () => {
+    const { localUserId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [localUserId]
@@ -144,6 +142,7 @@ describe('assignFederationGroupIdIfNeeded', () => {
   test('returns null for a 1:1 channel even with a federated member', async () => {
     // 1:1 channels never get a federationGroupId — Phase D / D2 only
     // applies to groups (the column is null for 1:1s by design).
+    const { localUserId, federatedUserAId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: false,
       memberIds: [localUserId, federatedUserAId]
@@ -153,6 +152,7 @@ describe('assignFederationGroupIdIfNeeded', () => {
   });
 
   test('assigns a UUID when a group includes any federated member', async () => {
+    const { localUserId, federatedUserAId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [localUserId, federatedUserAId]
@@ -171,6 +171,7 @@ describe('assignFederationGroupIdIfNeeded', () => {
   });
 
   test('is idempotent — a second call returns the same value', async () => {
+    const { localUserId, federatedUserAId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [localUserId, federatedUserAId]
@@ -183,6 +184,8 @@ describe('assignFederationGroupIdIfNeeded', () => {
 
 describe('buildFederatedMemberList', () => {
   test('attributes local users to our domain and federated users to their home', async () => {
+    const { localUserId, federatedUserAId, federatedUserBId } =
+      await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [localUserId, federatedUserAId, federatedUserBId]
@@ -213,6 +216,7 @@ describe('buildFederatedMemberList', () => {
     // and `federatedPublicId` (the user's id at their home). The
     // wire-shape member descriptor has to use the federated one so
     // peers can match.
+    const { federatedUserAId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [federatedUserAId]
@@ -224,6 +228,7 @@ describe('buildFederatedMemberList', () => {
   });
 
   test('peerDomains is empty for an all-local group', async () => {
+    const { localUserId } = await seedFederatedScenario();
     const channelId = await createChannel({
       isGroup: true,
       memberIds: [localUserId]

--- a/apps/server/src/utils/federation-dm-group-dispatch.ts
+++ b/apps/server/src/utils/federation-dm-group-dispatch.ts
@@ -1,0 +1,408 @@
+/**
+ * Phase D / D2 — server-side dispatchers that relay group DM
+ * lifecycle events to peer instances. Called from `dms/*` mutations
+ * after the local DB write succeeds; a failed relay is logged and
+ * does not roll back the local write (best-effort federation, same
+ * as existing dm-relay).
+ *
+ * Each helper resolves the set of peer instances involved (one per
+ * unique `federatedInstanceId` among the channel's members) and
+ * fires a signed POST per peer. The peer's mirror channel is keyed
+ * on `federationGroupId`, populated locally via either:
+ *   - `assignFederationGroupIdIfNeeded` on group create / 1:1→group
+ *     promotion when any member is federated
+ *   - inbound `/federation/dm-group-create` for groups originating
+ *     on a peer
+ */
+
+import { randomUUIDv7 } from 'bun';
+import { eq, inArray, and } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  dmChannelMembers,
+  dmChannels,
+  federationInstances,
+  users
+} from '../db/schema';
+import { config } from '../config';
+import { logger } from '../logger';
+import { relayToInstance } from './federation';
+
+type FederatedMember = {
+  publicId: string;
+  instanceDomain: string;
+  name: string;
+};
+
+type LocalMember = {
+  publicId: string;
+  name: string;
+};
+
+type ResolvedMember = FederatedMember | (LocalMember & {
+  instanceDomain: string; // == config.federation.domain for local
+});
+
+/**
+ * Build the wire-shape member list for a channel: every member with
+ * publicId, the instance domain they live on (our own domain for
+ * local users, their home domain for federated ones), and a display
+ * name. Skips users that have no publicId — we shouldn't be
+ * federating those, and the dm-relay path already requires publicId.
+ */
+async function buildFederatedMemberList(
+  dmChannelId: number
+): Promise<{
+  members: ResolvedMember[];
+  byUserId: Map<number, ResolvedMember>;
+  peerDomains: Set<string>;
+}> {
+  const memberRows = await db
+    .select({
+      userId: users.id,
+      publicId: users.publicId,
+      name: users.name,
+      isFederated: users.isFederated,
+      federatedInstanceId: users.federatedInstanceId,
+      federatedPublicId: users.federatedPublicId
+    })
+    .from(dmChannelMembers)
+    .innerJoin(users, eq(users.id, dmChannelMembers.userId))
+    .where(eq(dmChannelMembers.dmChannelId, dmChannelId));
+
+  // Resolve federated user instance domains in one batch
+  const federatedInstanceIds = Array.from(
+    new Set(
+      memberRows
+        .filter((m) => m.isFederated && m.federatedInstanceId)
+        .map((m) => m.federatedInstanceId as number)
+    )
+  );
+
+  const instanceDomainById = new Map<number, string>();
+  if (federatedInstanceIds.length > 0) {
+    const rows = await db
+      .select({
+        id: federationInstances.id,
+        domain: federationInstances.domain
+      })
+      .from(federationInstances)
+      .where(inArray(federationInstances.id, federatedInstanceIds));
+    for (const r of rows) instanceDomainById.set(r.id, r.domain);
+  }
+
+  const members: ResolvedMember[] = [];
+  const byUserId = new Map<number, ResolvedMember>();
+  const peerDomains = new Set<string>();
+
+  for (const row of memberRows) {
+    if (!row.publicId) continue;
+
+    let publicId: string;
+    let domain: string;
+    if (row.isFederated && row.federatedInstanceId) {
+      const inst = instanceDomainById.get(row.federatedInstanceId);
+      if (!inst) continue;
+      publicId = row.federatedPublicId ?? row.publicId;
+      domain = inst;
+      peerDomains.add(domain);
+    } else {
+      publicId = row.publicId;
+      domain = config.federation.domain;
+    }
+
+    const m: ResolvedMember = {
+      publicId,
+      instanceDomain: domain,
+      name: row.name
+    };
+    members.push(m);
+    byUserId.set(row.userId, m);
+  }
+
+  return { members, byUserId, peerDomains };
+}
+
+/**
+ * If the channel includes any federated member and doesn't yet have
+ * a `federationGroupId`, generate and assign one. Returns the value
+ * (existing or new) or null if the channel has no federated members.
+ *
+ * Called from createGroup and from the 1:1→group promotion path so
+ * the assignment happens before any relay.
+ */
+async function assignFederationGroupIdIfNeeded(
+  dmChannelId: number
+): Promise<string | null> {
+  const [channel] = await db
+    .select({
+      id: dmChannels.id,
+      isGroup: dmChannels.isGroup,
+      federationGroupId: dmChannels.federationGroupId
+    })
+    .from(dmChannels)
+    .where(eq(dmChannels.id, dmChannelId))
+    .limit(1);
+
+  if (!channel || !channel.isGroup) return null;
+  if (channel.federationGroupId) return channel.federationGroupId;
+
+  const hasFederated = await db
+    .select({ id: users.id })
+    .from(dmChannelMembers)
+    .innerJoin(users, eq(users.id, dmChannelMembers.userId))
+    .where(
+      and(
+        eq(dmChannelMembers.dmChannelId, dmChannelId),
+        eq(users.isFederated, true)
+      )
+    )
+    .limit(1);
+
+  if (hasFederated.length === 0) return null;
+
+  const federationGroupId = randomUUIDv7();
+  await db
+    .update(dmChannels)
+    .set({ federationGroupId, updatedAt: Date.now() })
+    .where(eq(dmChannels.id, dmChannelId));
+  return federationGroupId;
+}
+
+/**
+ * Announce the group + members to every peer instance involved.
+ * Fire-and-forget per peer; one failure doesn't block others.
+ */
+async function announceFederatedGroupCreate(
+  dmChannelId: number,
+  ownerUserId: number | null
+): Promise<void> {
+  const [channel] = await db
+    .select({
+      federationGroupId: dmChannels.federationGroupId,
+      name: dmChannels.name
+    })
+    .from(dmChannels)
+    .where(eq(dmChannels.id, dmChannelId))
+    .limit(1);
+  if (!channel?.federationGroupId) return;
+
+  const { members, byUserId, peerDomains } =
+    await buildFederatedMemberList(dmChannelId);
+  if (peerDomains.size === 0) return;
+
+  const ownerMember =
+    ownerUserId !== null ? byUserId.get(ownerUserId) : undefined;
+  if (!ownerMember) {
+    logger.warn(
+      '[announceFederatedGroupCreate] owner %s missing from members',
+      ownerUserId
+    );
+    return;
+  }
+
+  for (const peerDomain of peerDomains) {
+    relayToInstance(peerDomain, '/federation/dm-group-create', {
+      federationGroupId: channel.federationGroupId,
+      name: channel.name,
+      ownerPublicId: ownerMember.publicId,
+      members
+    }).catch((err) =>
+      logger.error(
+        '[announceFederatedGroupCreate] relay to %s failed: %o',
+        peerDomain,
+        err
+      )
+    );
+  }
+}
+
+/**
+ * Notify every peer instance that a member was added.
+ */
+async function announceFederatedGroupAddMember(
+  dmChannelId: number,
+  addedUserId: number
+): Promise<void> {
+  const [channel] = await db
+    .select({ federationGroupId: dmChannels.federationGroupId })
+    .from(dmChannels)
+    .where(eq(dmChannels.id, dmChannelId))
+    .limit(1);
+  if (!channel?.federationGroupId) return;
+
+  const [addedRow] = await db
+    .select({
+      publicId: users.publicId,
+      name: users.name,
+      isFederated: users.isFederated,
+      federatedInstanceId: users.federatedInstanceId,
+      federatedPublicId: users.federatedPublicId
+    })
+    .from(users)
+    .where(eq(users.id, addedUserId))
+    .limit(1);
+  if (!addedRow?.publicId) return;
+
+  let addedDomain = config.federation.domain;
+  let addedPublicId = addedRow.publicId;
+  if (addedRow.isFederated && addedRow.federatedInstanceId) {
+    const [inst] = await db
+      .select({ domain: federationInstances.domain })
+      .from(federationInstances)
+      .where(eq(federationInstances.id, addedRow.federatedInstanceId))
+      .limit(1);
+    if (!inst) return;
+    addedDomain = inst.domain;
+    addedPublicId = addedRow.federatedPublicId ?? addedPublicId;
+  }
+
+  const { peerDomains } = await buildFederatedMemberList(dmChannelId);
+  // Don't echo the announcement back to the added user's own instance —
+  // they originate the membership over there independently.
+  peerDomains.delete(addedDomain);
+  if (peerDomains.size === 0) return;
+
+  for (const peerDomain of peerDomains) {
+    relayToInstance(peerDomain, '/federation/dm-group-add-member', {
+      federationGroupId: channel.federationGroupId,
+      addedMember: {
+        publicId: addedPublicId,
+        instanceDomain: addedDomain,
+        name: addedRow.name
+      }
+    }).catch((err) =>
+      logger.error(
+        '[announceFederatedGroupAddMember] relay to %s failed: %o',
+        peerDomain,
+        err
+      )
+    );
+  }
+}
+
+/**
+ * Notify every peer instance that a member was removed.
+ */
+async function announceFederatedGroupRemoveMember(
+  dmChannelId: number,
+  removedUserId: number,
+  // Pass the public-id of the removed user explicitly. Caller already
+  // looked it up before deleting from dm_channel_members; recomputing
+  // post-delete would require keeping the row alive longer than
+  // intended.
+  removedPublicId: string
+): Promise<void> {
+  const [channel] = await db
+    .select({ federationGroupId: dmChannels.federationGroupId })
+    .from(dmChannels)
+    .where(eq(dmChannels.id, dmChannelId))
+    .limit(1);
+  if (!channel?.federationGroupId) return;
+
+  const { peerDomains } = await buildFederatedMemberList(dmChannelId);
+  if (peerDomains.size === 0) return;
+
+  // Use removedUserId for log only — the federation message just
+  // carries removedPublicId.
+  void removedUserId;
+
+  for (const peerDomain of peerDomains) {
+    relayToInstance(peerDomain, '/federation/dm-group-remove-member', {
+      federationGroupId: channel.federationGroupId,
+      removedPublicId
+    }).catch((err) =>
+      logger.error(
+        '[announceFederatedGroupRemoveMember] relay to %s failed: %o',
+        peerDomain,
+        err
+      )
+    );
+  }
+}
+
+/**
+ * Relay a single SKDM (one per recipient) to the recipient's home
+ * instance. Caller already validated that `toUser` is federated.
+ */
+async function relayFederatedSkdm(args: {
+  federationGroupId: string;
+  senderKeyId: number;
+  fromUserId: number;
+  toUserId: number;
+  distributionMessage: string;
+}): Promise<void> {
+  const [fromUser] = await db
+    .select({ publicId: users.publicId })
+    .from(users)
+    .where(eq(users.id, args.fromUserId))
+    .limit(1);
+  if (!fromUser?.publicId) return;
+
+  const [toUser] = await db
+    .select({
+      isFederated: users.isFederated,
+      federatedInstanceId: users.federatedInstanceId,
+      federatedPublicId: users.federatedPublicId
+    })
+    .from(users)
+    .where(eq(users.id, args.toUserId))
+    .limit(1);
+  if (
+    !toUser?.isFederated ||
+    !toUser.federatedInstanceId ||
+    !toUser.federatedPublicId
+  ) {
+    return;
+  }
+
+  const [instance] = await db
+    .select({
+      domain: federationInstances.domain,
+      status: federationInstances.status
+    })
+    .from(federationInstances)
+    .where(eq(federationInstances.id, toUser.federatedInstanceId))
+    .limit(1);
+  if (!instance || instance.status !== 'active') return;
+
+  await relayToInstance(instance.domain, '/federation/dm-sender-key', {
+    federationGroupId: args.federationGroupId,
+    senderKeyId: args.senderKeyId,
+    fromPublicId: fromUser.publicId,
+    toPublicId: toUser.federatedPublicId,
+    distributionMessage: args.distributionMessage
+  }).catch((err) =>
+    logger.error(
+      '[relayFederatedSkdm] relay to %s failed: %o',
+      instance.domain,
+      err
+    )
+  );
+}
+
+/**
+ * Get the federation_group_id of a channel (or null if same-instance
+ * or not yet assigned). Convenience for callers that just want to
+ * include the id in their dm-relay payload.
+ */
+async function getFederationGroupId(
+  dmChannelId: number
+): Promise<string | null> {
+  const [row] = await db
+    .select({ federationGroupId: dmChannels.federationGroupId })
+    .from(dmChannels)
+    .where(eq(dmChannels.id, dmChannelId))
+    .limit(1);
+  return row?.federationGroupId ?? null;
+}
+
+export {
+  announceFederatedGroupAddMember,
+  announceFederatedGroupCreate,
+  announceFederatedGroupRemoveMember,
+  assignFederationGroupIdIfNeeded,
+  buildFederatedMemberList,
+  getFederationGroupId,
+  relayFederatedSkdm
+};


### PR DESCRIPTION
…up DM foundation

Phase D / D2 — full client-side and server-side scaffolding for cross-instance E2EE DMs, including federated group DMs.

Client:

- ensureSession dispatches between same-instance getPreKeyBundle and federated getFederatedPreKeyBundle based on the recipient's Redux user record (`_identity` set to `name@domain` for federated users). DMs always use the home `signalStore` regardless of the recipient's instance.
- Bundle fetch failure surfaces a clear "encrypted DM unavailable" error rather than falling through to plaintext (Decision 2 / hard fail with retry).
- Same-instance verifyIdentity check is skipped for federated peers; rotation handling deferred to D3's broadcast path.
- store.ts header documents the channels-vs-DMs scoping rule.

Server — pre-key bundle:

- e2ee.getFederatedPreKeyBundle takes { userId } and resolves the federation metadata (instance domain + remote publicId) server- side. Client never sees federation-internal identifiers.

Server — schema:

- New `federation_group_id` column on `dm_channels` (nullable text, indexed) for group DMs that span instances. Each peer's mirror channel for the same logical group carries the same UUID. Migration 0015 with `ADD COLUMN IF NOT EXISTS` guard for the drizzle-tracking-wipe gotcha.

Server — federation routes (apps/server/src/http/federation-dm-group.ts):

- POST /federation/dm-group-create — receiver builds a local mirror channel from the announced member list, resolving each member to a local user (real for our users, shadow for federated). Idempotent on existing federationGroupId. Refuses if no local member is in the announced list.
- POST /federation/dm-group-add-member — receiver adds the announced member to the mirror.
- POST /federation/dm-group-remove-member — receiver removes the announced member from the mirror.
- POST /federation/dm-sender-key — receiver records a per-recipient SKDM in its local dm_e2ee_sender_keys keyed on shadow sender + local recipient + the channel's federationGroupId.

All four use Phase 4 signed-body verification on inbound and Phase D / D0 signed responses on outbound.

Server — dispatch helpers (federation-dm-group-dispatch.ts):

- assignFederationGroupIdIfNeeded — generates and persists a UUID when a group has any federated member.
- buildFederatedMemberList — produces the wire-shape member list, attributing local users to our domain and federated users to their home, with the set of unique peer domains involved.
- announceFederatedGroupCreate / AddMember / RemoveMember — fire- and-forget signed POSTs to each involved peer.
- relayFederatedSkdm — relays a single SKDM to a federated recipient's home instance.

Server — tRPC route updates:

- dms.createGroup: assigns federationGroupId after local creation and announces to peers if any member is federated.
- dms.addMember: same; also handles 1:1→group promotion that introduces a federated member by announcing the new group state rather than a stray add-member event.
- dms.removeMember: captures the removed user's federated public id before the row is deleted, then announces to peers.
- dms.distributeSenderKeys: splits distributions by recipient federation status. Local recipients keep the existing local write. Federated recipients get their SKDM relayed via /federation/dm-sender-key. Self-heals legacy groups by assigning a federationGroupId on the fly + re-announcing.
- dms.sendMessage: includes federationGroupId in the dm-relay payload for federated group DMs.

Server — dm-relay handler:

- For incoming relay with federationGroupId, looks up the local mirror by that column. Returns 404 if the mirror doesn't exist yet — refuses to silently route into a wrong 1:1 channel.
- 1:1 path unchanged.

Tests:

- federation-dm-group-dispatch.test.ts: assignFederationGroupIdIfNeeded (null for same-instance groups + 1:1s, UUID for federated groups, idempotent), buildFederatedMemberList (domain attribution, federated publicId surfacing, empty peerDomains for all-local).